### PR TITLE
Add in custom input abilities

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -40,6 +40,22 @@ For example, the following works:
 />
 ```
 
+You can additionally use your own custom input component by passing in the prop `inputElement`.
+If you're using `react-bootstrap` you can pass in `FormControl`
+
+For example:
+
+```js
+<MaskedTextInput
+  inputElement={FormControl}
+  mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+  placeholder="Enter a phone number"
+  guide={false}
+  id="my-input-id"
+/>
+```
+
+
 ## Documentation
 
 For more information about the `props` that you can pass to the component, see

--- a/react/README.md
+++ b/react/README.md
@@ -40,22 +40,6 @@ For example, the following works:
 />
 ```
 
-You can additionally use your own custom input component by passing in the prop `inputElement`.
-If you're using `react-bootstrap` you can pass in `FormControl`
-
-For example:
-
-```js
-<MaskedTextInput
-  inputElement={FormControl}
-  mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
-  placeholder="Enter a phone number"
-  guide={false}
-  id="my-input-id"
-/>
-```
-
-
 ## Documentation
 
 For more information about the `props` that you can pass to the component, see

--- a/react/componentDocumentation.md
+++ b/react/componentDocumentation.md
@@ -1,0 +1,18 @@
+# React Text Mask documentation
+
+You can use your own custom input component by passing in the prop `inputElement`.
+For example if you're using `react-bootstrap` you can pass in `FormControl`
+
+```js
+<MaskedTextInput
+  inputElement={FormControl}
+  getNode={(input) => findDOMNode(input)}
+  mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+  placeholder="Enter a phone number"
+  guide={false}
+  id="my-input-id"
+/>
+```
+
+When using a custom `inputElement` the `getNode` callback must return the HTML input element.
+The reason for this is that we require a `ref` to the actual HTML input to control the caret position.

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -17,7 +17,8 @@ export const MaskedInput = React.createClass({
     placeholderChar: PropTypes.string,
     onAccept: PropTypes.func,
     onReject: PropTypes.func,
-    keepCharPositions: PropTypes.bool
+    keepCharPositions: PropTypes.bool,
+    inputElement: PropTypes.element,
   },
 
   componentDidMount() {
@@ -34,7 +35,9 @@ export const MaskedInput = React.createClass({
 
   render() {
     const props = {...this.props}
+    const InputElement = props.inputElement || "input";
 
+    delete props.inputElement;
     delete props.mask
     delete props.guide
     delete props.pipe
@@ -44,7 +47,7 @@ export const MaskedInput = React.createClass({
     delete props.keepCharPositions
 
     return (
-      <input
+      <InputElement
         {...props}
         onChange={this.onChange}
         ref={(inputElement) => (this.inputElement = inputElement)}

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -35,9 +35,9 @@ export const MaskedInput = React.createClass({
 
   render() {
     const props = {...this.props}
-    const InputElement = props.inputElement || "input";
+    const InputElement = props.inputElement || 'input'
 
-    delete props.inputElement;
+    delete props.inputElement
     delete props.mask
     delete props.guide
     delete props.pipe

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -18,7 +18,7 @@ export const MaskedInput = React.createClass({
     onAccept: PropTypes.func,
     onReject: PropTypes.func,
     keepCharPositions: PropTypes.bool,
-    inputElement: PropTypes.element,
+    inputElement: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   },
 
   componentDidMount() {

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -19,12 +19,14 @@ export const MaskedInput = React.createClass({
     onReject: PropTypes.func,
     keepCharPositions: PropTypes.bool,
     inputElement: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    getNode: PropTypes.func,
   },
 
   componentDidMount() {
     const {props, props: {value}} = this
 
-    this.textMaskInputElement = createTextMaskInputElement({inputElement: this.inputElement, ...props})
+    const textMaskElement = !this.props.inputElement ? this.inputElement : this.props.getNode(this)
+    this.textMaskInputElement = createTextMaskInputElement({inputElement: textMaskElement, ...props})
 
     this.textMaskInputElement.update(value)
   },
@@ -38,6 +40,7 @@ export const MaskedInput = React.createClass({
     const InputElement = props.inputElement || 'input'
 
     delete props.inputElement
+    delete props.getNode
     delete props.mask
     delete props.guide
     delete props.pipe

--- a/react/test/reactTextMask.spec.jsx
+++ b/react/test/reactTextMask.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import ReactTestUtils from 'react-addons-test-utils'
 import packageJson from '../package.json'
+import { mount } from "enzyme";
 
 const MaskedInput = (isVerify()) ?
   require(`../${packageJson.main}`).default :
@@ -8,18 +8,27 @@ const MaskedInput = (isVerify()) ?
 
 describe('MaskedInput', () => {
   it('does not throw when instantiated', () => {
-    expect(() => ReactTestUtils.renderIntoDocument(
-      <MaskedInput mask='111-111' guide={true}/>
+    expect(() => mount(
+      <MaskedInput mask={[/\d/, /\d/, /\d/, /\d/]} guide={true}/>
     )).not.to.throw()
   })
 
   it('renders a single input element', () => {
-    const maskedInput = ReactTestUtils.renderIntoDocument(
-      <MaskedInput mask='111-111' guide={true}/>
+    const maskedInput = mount(
+      <MaskedInput mask={[/\d/, /\d/, /\d/, /\d/]} guide={true}/>
     )
 
-    expect(
-      () => ReactTestUtils.findRenderedDOMComponentWithTag(maskedInput, 'input')
-    ).not.to.throw()
+    expect(maskedInput.find('input').length).to.equal(1)
+  })
+
+  it('renders a single custom input element', () => {
+    const Input = (props) => <input {...props} data-custom="true" />
+    const maskedInput = mount(
+      <MaskedInput mask={[/\d/, /\d/, /\d/, /\d/]} guide={true} inputElement={Input}/>
+    )
+
+    expect(maskedInput.find('input').length).to.equal(1)
+    expect(maskedInput.find('input').prop('data-custom')).to.equal('true')
+      
   })
 })

--- a/react/test/reactTextMask.spec.jsx
+++ b/react/test/reactTextMask.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import packageJson from '../package.json'
-import { mount } from "enzyme";
+import {mount} from 'enzyme'
 
 const MaskedInput = (isVerify()) ?
   require(`../${packageJson.main}`).default :
@@ -22,13 +22,12 @@ describe('MaskedInput', () => {
   })
 
   it('renders a single custom input element', () => {
-    const Input = (props) => <input {...props} data-custom="true" />
+    const Input = (props) => <input {...props} data-custom='true' />
     const maskedInput = mount(
       <MaskedInput mask={[/\d/, /\d/, /\d/, /\d/]} guide={true} inputElement={Input}/>
     )
 
     expect(maskedInput.find('input').length).to.equal(1)
     expect(maskedInput.find('input').prop('data-custom')).to.equal('true')
-      
   })
 })

--- a/website/src/choices.jsx
+++ b/website/src/choices.jsx
@@ -55,7 +55,7 @@ export default map(
     placeholderChar: placeholderChars.whitespace
   }, {
     name: 'US zip code',
-    mask: [/[1-9]/, /\d/, /\d/, /\d/, /\d/],
+    mask: [/\d/, /\d/, /\d/, /\d/, /\d/],
     placeholder: '94303',
     placeholderChar: placeholderChars.underscore
   }, {


### PR DESCRIPTION
1) Add in ability to use a custom input element (for example `FormControl` from `react-bootstrap`)
2) Fix React tests however it doesn't look like they were running ever?
3) Zip codes can actually be `0` in the NE region of the US ;) (https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/ZIP_Code_zones.svg/2000px-ZIP_Code_zones.svg.png)