### PR TITLE
Change setValue to updateValue until officially deprecated.

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -34,7 +34,7 @@ export default class MaskedInputDirective implements ControlValueAccessor{
 
   writeValue(value: any) {
     this.textMaskInputElement.update(value)
-    this.formControl.setValue(value)
+    this.formControl.updateValue(value)
   }
 
   registerOnChange(fn: (value: any) => void) {


### PR DESCRIPTION
It's easy enough to switch this back when we need to. Supporting anything but the final public Angular 2 release shouldn't be a goal but it's good if we can give people more time to upgrade.