### PR TITLE
Fix ie10 backspace

### DIFF
--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -25,13 +25,13 @@ export const MaskedInput = React.createClass({
 
     this.textMaskInputElement = createTextMaskInputElement({inputElement: this.inputElement, ...props})
     this.textMaskInputElement.update(value)
-    this.inputElement.addEventListener('input', this.onChange, false)
+    // this.inputElement.addEventListener('input', this.onChange, false)
   },
 
   componentDidUpdate() {
     this.textMaskInputElement.update(this.props.value)
   },
-  
+
   render() {
     const props = {...this.props}
 
@@ -48,6 +48,7 @@ export const MaskedInput = React.createClass({
     return (
       <input
         {...props}
+        onInput={this.onChange}
         defaultValue={this.props.value}
         ref={(inputElement) => (this.inputElement = inputElement)}
       />

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -24,14 +24,14 @@ export const MaskedInput = React.createClass({
     const {props, props: {value}} = this
 
     this.textMaskInputElement = createTextMaskInputElement({inputElement: this.inputElement, ...props})
-
     this.textMaskInputElement.update(value)
+    this.inputElement.addEventListener('input', this.onChange, false)
   },
 
   componentDidUpdate() {
     this.textMaskInputElement.update(this.props.value)
   },
-
+  
   render() {
     const props = {...this.props}
 
@@ -42,11 +42,13 @@ export const MaskedInput = React.createClass({
     delete props.onAccept
     delete props.onReject
     delete props.keepCharPositions
+    delete props.value
+    delete props.onChange
 
     return (
       <input
         {...props}
-        onChange={this.onChange}
+        defaultValue={this.props.value}
         ref={(inputElement) => (this.inputElement = inputElement)}
       />
     )

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -25,7 +25,6 @@ export const MaskedInput = React.createClass({
 
     this.textMaskInputElement = createTextMaskInputElement({inputElement: this.inputElement, ...props})
     this.textMaskInputElement.update(value)
-    // this.inputElement.addEventListener('input', this.onChange, false)
   },
 
   componentDidUpdate() {


### PR DESCRIPTION
This turns the component into an uncontrolled input (it has been an uncontrolled input this entire time). Tells React not to bother with it. Use `onInput` and we're all good to go.