### PR TITLE
Ember: Update method of importing the core library

### DIFF
--- a/ember/.jshintrc
+++ b/ember/.jshintrc
@@ -2,8 +2,7 @@
   "predef": [
     "document",
     "window",
-    "-Promise",
-    "self"
+    "-Promise"
   ],
   "browser": true,
   "boss": true,

--- a/ember/addon/index.js
+++ b/ember/addon/index.js
@@ -1,4 +1,5 @@
-const textMaskCore = self.textMaskCore;
+import { textMaskCore } from 'ember-text-mask/textMaskCore';
+
 const { createTextMaskInputElement } = textMaskCore;
 
 export default textMaskCore;

--- a/ember/index.js
+++ b/ember/index.js
@@ -5,10 +5,10 @@ module.exports = {
   name: 'ember-text-mask',
 
   treeForAddon: function(tree) {
-    var textMaskAddonsPath = path.dirname(require.resolve('text-mask-core/dist/textMaskCore.js'));
-    var textMaskAddonsTree = this.treeGenerator(textMaskAddonsPath);
+    var textMaskPath = path.dirname(require.resolve('text-mask-core/dist/textMaskCore.js'));
+    var textMaskTree = this.treeGenerator(textMaskPath);
 
-    var trees = mergeTrees([textMaskAddonsTree, tree], {
+    var trees = mergeTrees([textMaskTree, tree], {
       overwrite: true
     });
 

--- a/ember/index.js
+++ b/ember/index.js
@@ -4,14 +4,14 @@
 module.exports = {
   name: 'ember-text-mask',
 
-  init: function(name) {
-    this._super.init && this._super.init.apply(this, arguments);
-    var assets_path = require('path').join('text-mask-core','dist','textMaskCore.js');
-    this.treePaths['vendor'] = require.resolve('text-mask-core').replace(assets_path, '');
-  },
+  treeForAddon: function(tree) {
+    var textMaskAddonsPath = path.dirname(require.resolve('text-mask-core/dist/textMaskCore.js'));
+    var textMaskAddonsTree = this.treeGenerator(textMaskAddonsPath);
 
-  included: function(app) {
-    this._super.included.apply(this, arguments);
-    app.import('vendor/text-mask-core/dist/textMaskCore.js');
+    var trees = mergeTrees([textMaskAddonsTree, tree], {
+      overwrite: true
+    });
+
+    return this._super.treeForAddon.call(this, trees);
   }
 };

--- a/ember/package.json
+++ b/ember/package.json
@@ -60,6 +60,7 @@
     "string formatting"
   ],
   "dependencies": {
+    "broccoli-merge-trees": "^1.1.4",
     "ember-cli-babel": "^5.1.6",
     "text-mask-core": "^0.15.2"
   },


### PR DESCRIPTION
Minor update to `text-mask/ember` - no functional changes to the addon

* Add `broccoli-merge-trees` dependency
* Use `broccoli-merge-trees` instead of `app.import` to import the core library.

This allows us to consume the core library without having to use a global to import the library.