### PR TITLE
Readme example and Typo fixes

### DIFF
--- a/componentDocumentation.md
+++ b/componentDocumentation.md
@@ -192,5 +192,5 @@ The `onReject` callback will receive an object with the following keys:
 
 ## `onAccept`
 
-You can provide an `onAccet` callback function which will be called when the user enters
+You can provide an `onAccept` callback function which will be called when the user enters
 a character that is accepted and displayed on the input element.

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -22,7 +22,7 @@ Then, use it as follows:
   // Assuming you have an input element in your HTML with the class .myInput
   var myInput = document.querySelector('.myInput')
 
-  textMask.maskInput({
+  vanillaTextMask.maskInput({
     inputElement: myInput,
     mask: phoneMask
   })


### PR DESCRIPTION
- Fix the example in the `vanilla` README
- Fix a typo in the componentDocumentation