### PR TITLE
Add destroy method docs to vanilla readme

### DIFF
--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -37,6 +37,29 @@ The object takes `element`, which is the `<input/>` element that you are masking
 accepts other values which are
 [documented here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme).
 
+## Vanilla Specific Documentation
+
+### Destroy - Removing Event Listener
+
+If you need to remove the event listener and stop masking the element, you can use the [`destroy` method](https://github.com/text-mask/text-mask/blob/master/vanilla/src/vanillaTextMask.js#L13-L15). Usage:
+
+```js
+import maskInput from 'vanilla-text-mask'
+
+//...
+
+let masker = maskInput({
+  inputElement: inputEl,
+  mask: []
+})
+
+//...
+
+const aLaterFunction = () => {
+  masker.destroy()
+}
+```
+
 ## Example
 
 To see an example of the code running, follow these steps:


### PR DESCRIPTION
It took me a few minutes to dig around and find where this feature might live. Maybe this could save people some time? 

I wasn't sure where to put the explanation though. It seems only valid for the vanilla implementation, as it's a built in 'directive' for angular/react it seems.