### PR TITLE
Change updateValue to setValue for RC.6 compatibility.

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -51,7 +51,12 @@ export default class MaskedInputDirective implements ControlValueAccessor{
       this.textMaskInputElement.update(value)
     }
 
-    this.formControl.setValue(value)
+    try { //Try RC.5+ setValue
+      this.formControl.setValue(value)
+    }
+    catch (e) { //Fallback to RC.4 updateValue
+      this.formControl.updateValue(value)
+    }
   }
 
   registerOnChange(fn: (value: any) => void) {

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -51,7 +51,7 @@ export default class MaskedInputDirective implements ControlValueAccessor{
       this.textMaskInputElement.update(value)
     }
 
-    this.formControl.updateValue(value)
+    this.formControl.setValue(value)
   }
 
   registerOnChange(fn: (value: any) => void) {


### PR DESCRIPTION
Seems updateValue was most definitely deprecated in RC.5 as it now throws errors in RC.6.

NOTE: This is a breaking change for anybody using RC.4 or older.