### PR TITLE
Call onInput in onInit to mask initiial value.

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -42,6 +42,9 @@ export default class MaskedInputDirective implements OnInit, ControlValueAccesso
     this.textMaskInputElement = createTextMaskInputElement(
       Object.assign({inputElement: this.inputElement}, this.textMaskConfig)
     )
+
+    // This ensures that initial model value gets masked
+    setTimeout(() => this.onInput())
   }
 
   writeValue(value: any) {


### PR DESCRIPTION
Turns out this is needed still!! Initial value was no longer getting masked...not sure how that slipped by. Sorry!