### PR TITLE
(Angular2) React on setDisabledState

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -1,4 +1,4 @@
-import {Directive, ElementRef, Input, OnInit} from '@angular/core'
+import {Directive, ElementRef, forwardRef, Input, OnInit, Renderer} from '@angular/core'
 import {FormControl, NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms'
 import createTextMaskInputElement from '../../core/src/createTextMaskInputElement'
 
@@ -7,9 +7,11 @@ import createTextMaskInputElement from '../../core/src/createTextMaskInputElemen
     '(input)': 'onInput()'
   },
   selector: '[textMask]',
-  providers: [
-    {provide: NG_VALUE_ACCESSOR, useExisting: MaskedInputDirective, multi: true}
-  ]
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => MaskedInputDirective),
+    multi: true
+  }]
 })
 export default class MaskedInputDirective implements OnInit, ControlValueAccessor{
   private textMaskInputElement: any
@@ -28,7 +30,7 @@ export default class MaskedInputDirective implements OnInit, ControlValueAccesso
 
   formControl: FormControl = new FormControl()
 
-  constructor(private element: ElementRef) {}
+  constructor(private renderer: Renderer, private element: ElementRef) {}
 
   ngOnInit() {
     if (this.element.nativeElement.tagName === 'INPUT') {
@@ -64,6 +66,10 @@ export default class MaskedInputDirective implements OnInit, ControlValueAccesso
   onInput() {
     this.textMaskInputElement.update()
     this.writeValue(this.inputElement.value)
+  }
+
+  setDisabledState(isDisabled: boolean) {
+    this.renderer.setElementProperty(this.element.nativeElement, 'disabled', isDisabled)
   }
 }
 

--- a/angular2/test/angular2TextMask.spec.js
+++ b/angular2/test/angular2TextMask.spec.js
@@ -10,14 +10,16 @@ const MaskedInput = (isVerify()) ?
 describe('MaskedInput', () => {
   let inputElement
   let ngModel
+  let renderer
 
   beforeEach(() => {
     inputElement = document.createElement('input')
+    renderer = {}
   })
 
   it('does not throw when instantiated', () => {
     expect(() => {
-      const maskedInput = new MaskedInput({nativeElement: inputElement}, ngModel)
+      const maskedInput = new MaskedInput(renderer, {nativeElement: inputElement}, ngModel)
 
       maskedInput.ngOnInit({mask: '(111)'})
 


### PR DESCRIPTION
Currently you cannot disable a masked input field using [disabled]="...".
This change fixes this issue.

Furthermore, I included forwardRef as it is good practice as DI might not encounter the class. forwardRef is used to resolve the class once loaded.