### PR TITLE
Remove .js from import of emailPipe

### DIFF
--- a/addons/src/emailMask.js
+++ b/addons/src/emailMask.js
@@ -1,4 +1,4 @@
-import emailPipe from './emailPipe.js'
+import emailPipe from './emailPipe'
 
 const asterisk = '*'
 const dot = '.'


### PR DESCRIPTION
This solve a problem we are solving for Ember & FastBoot integration. Related issue: https://github.com/text-mask/ember-text-mask-addons/issues/12