### PR TITLE
Update Ember-text-mask

### DIFF
--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { createTextMaskInputElement } from 'ember-text-mask';
+import createTextMaskInputElement from 'ember-text-mask/createTextMaskInputElement';
 
 const { computed, observer, on, TextField } = Ember;
 

--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -1,6 +1,16 @@
 import Ember from 'ember';
 import { createTextMaskInputElement } from 'ember-text-mask';
 
+const { computed, observer, on, TextField } = Ember;
+
+function _createTextMaskInputElement(...args) {
+  return computed(...args, function () {
+    let config = this.getProperties(...args);
+    config.inputElement = this.get('element');
+    return createTextMaskInputElement(config);
+  });
+}
+
 /*
 
   ## MaskedInputComponent
@@ -23,28 +33,21 @@ import { createTextMaskInputElement } from 'ember-text-mask';
   });
   ```
 */
-export default Ember.TextField.extend({
+export default TextField.extend({
 
   mask: [],
 
-  inputElement: Ember.computed.readOnly('element'),
-
-  createTextMaskInputElement,
-
-  initTextMaskInputElement() {
-    this.set('textMaskInputElement', this.createTextMaskInputElement(this.getProperties('inputElement', 'mask', 'guide', 'placeholderChar', 'keepCharPositions', 'pipe', 'onReject', 'onAccept')));
-  },
-
-  didInsertElement() {
-    this._super(...arguments);
-    this.initTextMaskInputElement();
-  },
+  textMaskInputElement: _createTextMaskInputElement('mask', 'guide', 'placeholderChar', 'keepCharPositions', 'pipe', 'onReject', 'onAccept'),
 
   update() {
     this.get('textMaskInputElement').update(...arguments);
   },
 
-  _input: Ember.on('input', function() {
+  _textMaskInputElementChanged: observer('textMaskInputElement', function () {
+    this.update();
+  }),
+
+  _input: on('input', function() {
     this.update();
   })
 });

--- a/ember/addon/index.js
+++ b/ember/addon/index.js
@@ -1,4 +1,6 @@
 import createTextMaskInputElement from 'ember-text-mask/createTextMaskInputElement';
 import conformToMask from 'ember-text-mask/conformToMask';
+import MaskedInputComponent from 'ember-text-mask/components/masked-input';
 
+export default MaskedInputComponent;
 export { createTextMaskInputElement, conformToMask };

--- a/ember/package.json
+++ b/ember/package.json
@@ -65,6 +65,9 @@
     "text-mask-core": "^1.1.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "versionCompatibility": {
+      "ember": ">=2.0.0"
+    }
   }
 }

--- a/ember/tests/integration/components/masked-input-test.js
+++ b/ember/tests/integration/components/masked-input-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const mask = ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
-
 moduleForComponent('masked-input', 'Integration | Component | masked input', {
   integration: true
 });
@@ -13,55 +11,9 @@ test('it renders an input element', function(assert) {
 });
 
 test('placeholder attribute can be passed in', function(assert) {
-  this.set('mask', mask);
-
-  this.render(hbs`{{masked-input mask=mask placeholder=placeholder}}`);
+  this.render(hbs`{{masked-input placeholder=placeholder}}`);
   assert.ok( ! this.$('input').attr('placeholder') );
 
   this.set('placeholder', "Some Placeholder Text");
   assert.equal(this.$('input').attr('placeholder'), 'Some Placeholder Text');
-});
-
-test('attributes can be passed in from the template', function(assert) {
-  assert.expect(11);
-
-  const placeholderChar = '_';
-  const pipe = function () { return ''; };
-  const onReject = function () { return ''; };
-  const onAccept = function () { return ''; };
-
-  this.setProperties({
-    mask,
-    guide: true,
-    placeholderChar,
-    keepCharPositions: true,
-    pipe,
-    onReject,
-    onAccept,
-    createTextMaskInputElement: (config) => {
-      assert.ok(config.inputElement);
-      assert.equal(config.mask, mask);
-      assert.equal(config.guide, true);
-      assert.equal(config.placeholderChar, placeholderChar);
-      assert.deepEqual(config.keepCharPositions, true);
-      assert.deepEqual(config.pipe, pipe);
-      assert.equal(typeof config.pipe, 'function');
-      assert.deepEqual(config.onReject, onReject);
-      assert.equal(typeof config.onReject, 'function');
-      assert.deepEqual(config.onAccept, onAccept);
-      assert.equal(typeof config.onAccept, 'function');
-    }
-  });
-
-  this.render(hbs`
-    {{masked-input
-      mask=mask
-      guide=guide
-      placeholderChar=placeholderChar
-      keepCharPositions=keepCharPositions
-      pipe=pipe
-      onReject=onReject
-      onAccept=onAccept
-      createTextMaskInputElement=createTextMaskInputElement}}
-  `);
 });

--- a/ember/tests/unit/components/masked-input-test.js
+++ b/ember/tests/unit/components/masked-input-test.js
@@ -1,8 +1,4 @@
-import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
-
-const { run } = Ember;
-const mask = ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
 
 moduleForComponent('masked-input', 'Unit | Component | masked input', {
   unit: true
@@ -37,33 +33,10 @@ test('mask defaults to an empty array', function(assert) {
   assert.deepEqual(component.get('mask'), []);
 });
 
-test('inputElement is an alias of element', function(assert) {
-  assert.expect(1);
-
-  var component = this.subject();
-  this.render();
-
-  assert.equal(component.get('inputElement'), component.get('element'));
-});
-
-test('createTextMaskInputElement() method exists', function(assert) {
-  assert.expect(1);
-
-  var component = this.subject();
-  this.render();
-  assert.equal(typeof component.createTextMaskInputElement, 'function');
-  component.createTextMaskInputElement({
-    inputElement: component.get('element'),
-    mask
-  });
-});
-
-test('initTextMaskInputElement() method sets textMaskInputElement property', function(assert) {
+test('textMaskInputElement property is initialized', function(assert) {
   assert.expect(4);
-  var component = this.subject({ didInsertElement: null });
+  var component = this.subject();
   this.render();
-
-  run(() => component.initTextMaskInputElement());
 
   const textMaskInputElement = component.get('textMaskInputElement');
   assert.equal(typeof textMaskInputElement, 'object');
@@ -72,49 +45,27 @@ test('initTextMaskInputElement() method sets textMaskInputElement property', fun
   assert.equal(typeof textMaskInputElement.update, 'function');
 });
 
-test('config is correctly passed to createTextMaskInputElement() method', function(assert) {
-  assert.expect(11);
+test('changing textMaskInputElement calls textMaskInputElement.update()', function(assert) {
+  assert.expect(1);
 
-  const placeholderChar = '_';
-  const pipe = function () { return ''; };
-  const onReject = function () { return ''; };
-  const onAccept = function () { return ''; };
-
-  this.subject({
-    mask,
-    guide: true,
-    placeholderChar,
-    keepCharPositions: true,
-    pipe,
-    onReject,
-    onAccept,
-    createTextMaskInputElement: (config) => {
-      assert.ok(config.inputElement);
-      assert.equal(config.mask, mask);
-      assert.equal(config.guide, true);
-      assert.equal(config.placeholderChar, placeholderChar);
-      assert.deepEqual(config.keepCharPositions, true);
-      assert.deepEqual(config.pipe, pipe);
-      assert.equal(typeof config.pipe, 'function');
-      assert.deepEqual(config.onReject, onReject);
-      assert.equal(typeof config.onReject, 'function');
-      assert.deepEqual(config.onAccept, onAccept);
-      assert.equal(typeof config.onAccept, 'function');
-    }
-  });
+  let component = this.subject();
   this.render();
+
+  component.set('textMaskInputElement', {
+    update: () => assert.ok(true)
+  });
 });
 
 test('update() method calls textMaskInputElement.update()', function(assert) {
   assert.expect(1);
 
-  var component = this.subject({ mask });
+  let component = this.subject({
+    _textMaskInputElementChanged(){},
+    textMaskInputElement: {
+      update: () => assert.ok(true)
+    }
+  });
+
   this.render();
-
-  // stub the textMaskInputElement
-  run(() => component.set('textMaskInputElement', {
-    update: () => assert.ok(true)
-  }));
-
   component.update();
 });


### PR DESCRIPTION
This PR adds support for changing the text-mask config properties after rendering the masked-input component.

Fixes Known issue: [Updating the mask or other values after initialization](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#updating-the-mask-or-other-values-after-initialization)