### PR TITLE
Fix: correct value is written back to the form control

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, forwardRef, Input, NgModule, Renderer } from '@angular/core'
+import { Directive, ElementRef, forwardRef, Input, NgModule, Renderer, Injector } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, NgControl } from '@angular/forms'
 import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore'
@@ -15,12 +15,14 @@ import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore'
     multi: true
   }]
 })
-export class MaskedInputDirective implements ControlValueAccessor{
+export class MaskedInputDirective implements ControlValueAccessor {
   private textMaskInputElement: any
   private inputElement:HTMLInputElement
 
   // stores the last value for comparison
   private lastValue: any
+
+  private control: NgControl
 
   @Input('textMask')
   textMaskConfig = {
@@ -29,12 +31,14 @@ export class MaskedInputDirective implements ControlValueAccessor{
     placeholderChar: '_',
     pipe: undefined,
     keepCharPositions: false,
+    onReject: undefined,
+    onAccept: undefined
   }
 
   _onTouched = () => {}
   _onChange = (_: any) => {}
 
-  constructor(private renderer: Renderer, private element: ElementRef) {}
+  constructor(private renderer: Renderer, private element: ElementRef, private injector: Injector) {}
 
   private setupMask() {
     if (this.element.nativeElement.tagName === 'INPUT') {
@@ -50,6 +54,8 @@ export class MaskedInputDirective implements ControlValueAccessor{
           Object.assign({inputElement: this.inputElement}, this.textMaskConfig)
       )
     }
+
+    this.control = this.injector.get(NgControl)
   }
 
   writeValue(value: any) {
@@ -59,6 +65,11 @@ export class MaskedInputDirective implements ControlValueAccessor{
 
     if (this.textMaskInputElement !== undefined) {
       this.textMaskInputElement.update(value)
+
+      if (value !== this.inputElement.value) {
+        this.onInput(this.inputElement.value)
+        this.control.control.markAsPristine()
+      }
     }
   }
 
@@ -71,11 +82,17 @@ export class MaskedInputDirective implements ControlValueAccessor{
       this.setupMask()
     }
 
-    this.textMaskInputElement.update(value)
-    // check against the last value to prevent firing ngModelChange despite no changes
-    if (this.lastValue !== value) {
-      this.lastValue = value
-      this._onChange(value)
+    if (this.textMaskInputElement !== undefined) {
+      this.textMaskInputElement.update(value)
+      
+      // get the updated value
+      value = this.inputElement.value
+
+      // check against the last value to prevent firing ngModelChange despite no changes
+      if (this.lastValue !== value) {
+        this.lastValue = value
+        this._onChange(value)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes an regression introduced by v5 where an incorrect value is written back to form control. Furthermore, this adds another check if the textMaskInputElement is present