### PR TITLE
BUGFIX: Allow createNumberMask suffix to contain numbers

### DIFF
--- a/addons/src/createNumberMask.js
+++ b/addons/src/createNumberMask.js
@@ -23,6 +23,7 @@ export default function createNumberMask({
   integerLimit = null
 } = {}) {
   const prefixLength = prefix && prefix.length || 0
+  const suffixLength = suffix && suffix.length || 0
   const thousandsSeparatorSymbolLength = thousandsSeparatorSymbol && thousandsSeparatorSymbol.length || 0
 
   function numberMask(rawValue = emptyString) {
@@ -42,6 +43,11 @@ export default function createNumberMask({
     let integer
     let fraction
     let mask
+
+    // remove the suffix
+    if (rawValue.slice(suffixLength * -1) === suffix) {
+      rawValue = rawValue.slice(0, suffixLength * -1)
+    }
 
     if (hasDecimal && (allowDecimal || requireDecimal)) {
       integer = rawValue.slice(rawValue.slice(0, prefixLength) === prefix ? prefixLength : 0, indexOfLastDecimal)

--- a/addons/test/createNumberMask.spec.js
+++ b/addons/test/createNumberMask.spec.js
@@ -21,6 +21,24 @@ describe('createNumberMask', () => {
     expect(numberMask('12')).to.deep.equal([/\d/, /\d/, ' ', '$'])
   })
 
+  it('works when the prefix contains numbers', () => {
+    let numberMask = createNumberMask({prefix: 'm2 '})
+
+    expect(numberMask('m2 1')).to.deep.equal(['m', '2', ' ', /\d/])
+  })
+
+  it('works when the suffix contains numbers', () => {
+    let numberMask = createNumberMask({prefix: '', suffix: ' m2'})
+
+    expect(numberMask('1 m2')).to.deep.equal([/\d/, ' ', 'm', '2'])
+  })
+
+  it('works when there is a decimal and the suffix contains numbers', () => {
+    let numberMask = createNumberMask({prefix: '', suffix: ' m2', allowDecimal: true})
+
+    expect(numberMask('1.2 m2')).to.deep.equal([/\d/, '[]', '.', '[]', /\d/, ' ', 'm', '2'])
+  })
+
   it('can be configured to add a thousands separator or not', () => {
     let numberMaskWithoutThousandsSeparator = createNumberMask({includeThousandsSeparator: false})
     expect(numberMaskWithoutThousandsSeparator('1000')).to.deep.equal(['$', /\d/, /\d/, /\d/, /\d/])


### PR DESCRIPTION
This PR introduces a fix for cases where the `createNumberMask#suffix` contains numbers.

Fixes #397