### PR TITLE
Check for existense of `navigator` to be isomorphic friendly

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -7,7 +7,7 @@ const strFunction = 'function'
 const emptyString = ''
 const strNone = 'none'
 const strObject = 'object'
-const isAndroid = /Android/i.test(navigator && navigator.userAgent)
+const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)
 
 export default function createTextMaskInputElement({
   inputElement,


### PR DESCRIPTION
The recent fix for Android's caret issues (https://github.com/text-mask/text-mask/pull/400) causes an error when using this component in isomorphic rendering due to `navigator` being unavailable.

This adds a `typeof navigator !== 'undefined'` ahead of its usage to prevent things blowing up.