### PR TITLE
Update ember-component for core v3.2

### DIFF
--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -33,30 +33,31 @@ function _config(...args) {
 */
 export default TextField.extend({
 
-  /*
-    ## mask {Array|Function|Boolean}
-
-    The mask can be an array, or a function that returns an array.
-
-    You can also set the mask to `false`, or return `false` from a mask function
-    to disable the mask completely.
-  */
   mask: [],
 
   /*
     ## config {Object}
 
-    This is a computed property and will update when any of the dependent properties
-    update.  By default it will read the properties off the component root.
+    This is a computed property and will re-compute when any of the dependent properties
+    update.  By default it will read the properties off the component root, you
+    can pass in attrbutes to the component through the template.
+
+    ```hbs
+    {{masked-input
+      mask=customMask
+      guide=true}}
+    ```
   */
   config: _config('mask', 'guide', 'placeholderChar', 'keepCharPositions', 'pipe'),
 
   /*
     ## textMaskInputElement {Object}
 
-    `textMaskInputElement` is the object that is returned from calling `createTextMaskInputElement`.
-    This is a computed property.  It is dependent on the `config` property and
-    will re-compute whenever the config property changes.
+    `textMaskInputElement` is the object that is returned from calling the
+    `createTextMaskInputElement`. method.
+
+    This is a computed property and will re-compute whenever the `config` property
+    changes.
   */
   textMaskInputElement: computed('config', function () {
     let config = get(this, 'config');
@@ -64,31 +65,13 @@ export default TextField.extend({
     return this.createTextMaskInputElement(config);
   }),
 
-  /*
-    ## createTextMaskInputElement(config)
-
-    This method returns the `textMaskInputElement` object.  It is called when
-    the `textMaskInputElement` property is computed...
-  */
   createTextMaskInputElement,
 
-  /*
-    ## update(rawValue, config)
-
-    This method is called on every key press (and on initial render).
-  */
-  update(/*rawValue, config*/) {
+  update() {
     this.get('textMaskInputElement').update(...arguments);
   },
 
-  // call `update` method when the element is rendered.
-  _didInsertElement: on('didInsertElement', function() {
-    this.update();
-  }),
-
-
-  // call `update` method on input.
-  _input: on('input', function() {
+  _didRender: on('input', 'didRender', function() {
     this.update();
   })
 });

--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -33,26 +33,61 @@ function _config(...args) {
 */
 export default TextField.extend({
 
+  /*
+    ## mask {Array|Function|Boolean}
+
+    The mask can be an array, or a function that returns an array.
+
+    You can also set the mask to `false`, or return `false` from a mask function
+    to disable the mask completely.
+  */
   mask: [],
 
+  /*
+    ## config {Object}
+
+    This is a computed property and will update when any of the dependent properties
+    update.  By default it will read the properties off the component root.
+  */
   config: _config('mask', 'guide', 'placeholderChar', 'keepCharPositions', 'pipe'),
 
+  /*
+    ## textMaskInputElement {Object}
+
+    `textMaskInputElement` is the object that is returned from calling `createTextMaskInputElement`.
+    This is a computed property.  It is dependent on the `config` property and
+    will re-compute whenever the config property changes.
+  */
   textMaskInputElement: computed('config', function () {
     let config = get(this, 'config');
     config.inputElement = get(this, 'element');
     return this.createTextMaskInputElement(config);
   }),
 
+  /*
+    ## createTextMaskInputElement(config)
+
+    This method returns the `textMaskInputElement` object.  It is called when
+    the `textMaskInputElement` property is computed...
+  */
   createTextMaskInputElement,
 
-  update() {
+  /*
+    ## update(rawValue, config)
+
+    This method is called on every key press (and on initial render).
+  */
+  update(/*rawValue, config*/) {
     this.get('textMaskInputElement').update(...arguments);
   },
 
+  // call `update` method when the element is rendered.
   _didInsertElement: on('didInsertElement', function() {
     this.update();
   }),
 
+
+  // call `update` method on input.
   _input: on('input', function() {
     this.update();
   })

--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -71,7 +71,7 @@ export default TextField.extend({
     this.get('textMaskInputElement').update(...arguments);
   },
 
-  _didRender: on('input', 'didRender', function() {
+  _input: on('input', 'didRender', function() {
     this.update();
   })
 });

--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -1,13 +1,11 @@
 import Ember from 'ember';
 import createTextMaskInputElement from 'ember-text-mask/createTextMaskInputElement';
 
-const { computed, observer, on, TextField } = Ember;
+const { computed, get, getProperties, on, TextField } = Ember;
 
-function _createTextMaskInputElement(...args) {
+function _config(...args) {
   return computed(...args, function () {
-    let config = this.getProperties(...args);
-    config.inputElement = this.get('element');
-    return createTextMaskInputElement(config);
+    return getProperties(this, ...args);
   });
 }
 
@@ -37,15 +35,19 @@ export default TextField.extend({
 
   mask: [],
 
-  textMaskInputElement: _createTextMaskInputElement('mask', 'guide', 'placeholderChar', 'keepCharPositions', 'pipe'),
+  config: _config('mask', 'guide', 'placeholderChar', 'keepCharPositions', 'pipe'),
+
+  textMaskInputElement: computed('config', function () {
+    let config = get(this, 'config');
+    config.inputElement = get(this, 'element');
+    return this.createTextMaskInputElement(config);
+  }),
+
+  createTextMaskInputElement,
 
   update() {
     this.get('textMaskInputElement').update(...arguments);
   },
-
-  _textMaskInputElementChanged: observer('textMaskInputElement', function () {
-    this.update();
-  }),
 
   _didInsertElement: on('didInsertElement', function() {
     this.update();

--- a/ember/addon/components/masked-input.js
+++ b/ember/addon/components/masked-input.js
@@ -61,7 +61,7 @@ export default TextField.extend({
   */
   textMaskInputElement: computed('config', function () {
     let config = get(this, 'config');
-    config.inputElement = get(this, 'element');
+    config.inputElement = this.element;
     return this.createTextMaskInputElement(config);
   }),
 

--- a/ember/config/ember-try.js
+++ b/ember/config/ember-try.js
@@ -8,17 +8,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-2.0',
       bower: {
         dependencies: {

--- a/ember/package.json
+++ b/ember/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "broccoli-merge-trees": "^1.1.4",
     "ember-cli-babel": "^5.1.7",
-    "text-mask-core": "^3.1.0"
+    "text-mask-core": "^3.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/ember/tests/integration/components/masked-input-test.js
+++ b/ember/tests/integration/components/masked-input-test.js
@@ -27,3 +27,35 @@ test('mask is initialised on first render', function(assert) {
   // assert.equal(this.get('value'), '(123) 456-7890');
   assert.equal(this.get('value'), '1234567890', 'initializing text mask should not change the model');
 });
+
+test('mask property can be changed', function(assert) {
+  this.set('mask', ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]);
+  this.set('value', '1234567890');
+  this.render(hbs`{{masked-input mask=mask value=value}}`);
+  assert.equal(this.$('input')[0].value, '(123) 456-7890');
+
+  this.set('mask', ['[', /[1-9]/, /\d/, /\d/, ']', '-', /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/]);
+  assert.equal(this.$('input')[0].value, '[123]-456 7890');
+});
+
+test('guide property can be changed', function(assert) {
+  this.set('mask', ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]);
+  this.set('value', '12345');
+  this.set('guide', false);
+  this.render(hbs`{{masked-input mask=mask guide=guide value=value}}`);
+  assert.equal(this.$('input')[0].value, '(123) 45');
+
+  this.set('guide', true);
+  assert.equal(this.$('input')[0].value, '(123) 45_-____');
+});
+
+test('placeholderChar property can be changed', function(assert) {
+  this.set('mask', ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]);
+  this.set('value', '12345');
+
+  this.render(hbs`{{masked-input mask=mask placeholderChar=placeholderChar value=value}}`);
+  assert.equal(this.$('input')[0].value, '(123) 45_-____');
+
+  this.set('placeholderChar', '*');
+  assert.equal(this.$('input')[0].value, '(123) 45*-****');
+});

--- a/ember/tests/integration/components/masked-input-test.js
+++ b/ember/tests/integration/components/masked-input-test.js
@@ -59,3 +59,33 @@ test('placeholderChar property can be changed', function(assert) {
   this.set('placeholderChar', '*');
   assert.equal(this.$('input')[0].value, '(123) 45*-****');
 });
+
+test('pipe method is called', function(assert) {
+  assert.expect(2);
+  this.set('mask', ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]);
+  this.set('value', '(123) 45_-____');
+  this.set('pipe', (value) => {
+    assert.equal(value, this.get('value'));
+    return 'abc';
+  });
+
+  this.render(hbs`{{masked-input mask=mask pipe=pipe value=value}}`);
+  assert.equal(this.$('input')[0].value, 'abc');
+});
+
+test('pipe property can be changed', function(assert) {
+  assert.expect(2);
+  this.set('mask', ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]);
+  this.set('value', '(123) 45_-_6__');
+  this.set('pipe', () => {
+    return '1';
+  });
+
+  this.render(hbs`{{masked-input mask=mask pipe=pipe value=value}}`);
+  assert.equal(this.$('input')[0].value, '1');
+
+  this.set('pipe', () => {
+    return '2';
+  });
+  assert.equal(this.$('input')[0].value, '2');
+});

--- a/ember/tests/unit/components/masked-input-test.js
+++ b/ember/tests/unit/components/masked-input-test.js
@@ -45,15 +45,76 @@ test('textMaskInputElement property is initialized', function(assert) {
   assert.equal(typeof textMaskInputElement.update, 'function');
 });
 
-test('changing textMaskInputElement calls textMaskInputElement.update()', function(assert) {
-  assert.expect(1);
+test('createTextMaskInputElement() is called on render with the correct config', function(assert) {
+  assert.expect(6);
 
-  let component = this.subject();
+  let mask = [/\d/];
+  let guide = true;
+  let placeholderChar = true;
+  let keepCharPositions = true;
+  let pipe = () => {};
+
+  this.subject({
+    mask,
+    guide,
+    placeholderChar,
+    keepCharPositions,
+    pipe,
+    createTextMaskInputElement: (config) => {
+      assert.deepEqual(config.mask, mask);
+      assert.equal(config.guide, guide);
+      assert.equal(config.placeholderChar, placeholderChar);
+      assert.equal(config.keepCharPositions, keepCharPositions);
+      assert.deepEqual(config.pipe, pipe);
+      assert.deepEqual(typeof config.inputElement, 'object');
+      return {
+        update(){}
+      };
+    }
+  });
+  this.render();
+});
+
+test('changing config calls createTextMaskInputElement()', function(assert) {
+  assert.expect(6);
+
+  let config = {
+    mask: [/\d/],
+    guide: undefined,
+    placeholderChar: undefined,
+    keepCharPositions: undefined,
+    pipe: undefined
+  };
+
+  let component = this.subject({
+    createTextMaskInputElement() {
+      return {
+        update(){}
+      };
+    }
+  });
   this.render();
 
-  component.set('textMaskInputElement', {
-    update: () => assert.ok(true)
-  });
+  component.createTextMaskInputElement = (_config) => {
+    assert.deepEqual(_config.mask, config.mask);
+    assert.equal(typeof config.guide, "undefined");
+    assert.equal(typeof config.placeholderChar, "undefined");
+    assert.equal(typeof config.keepCharPositions, "undefined");
+    assert.deepEqual(typeof config.pipe, "undefined");
+    assert.deepEqual(typeof config.inputElement, 'object', 'inputElement should be an object');
+    return {
+      update(){}
+    };
+  };
+
+  component.set('config', config);
+  component.update();
+});
+
+test('createTextMaskInputElement is a function', function(assert) {
+  assert.expect(1);
+  let component = this.subject();
+  assert.equal(typeof component.createTextMaskInputElement, 'function');
 });
 
 test('update() method is called when component is rendered', function(assert) {
@@ -71,7 +132,6 @@ test('update() method calls textMaskInputElement.update()', function(assert) {
   assert.expect(1);
 
   let component = this.subject({
-    _textMaskInputElementChanged(){},
     textMaskInputElement: {
       update: () => assert.ok(true)
     }


### PR DESCRIPTION
This PR updates the ember component to make more use of the new reactivity built into the core with v3.2

* Update text-mask-core to `^3.2.0`
* Re-organise the ember component to allow a config object to passed into the `textMaskInputElement`.

`text-mask-core` now stores the config as an object.. This object can be mutated after initialising text-mask, and text-mask will then use the updated config in the next `update`.  You can also pass in a config object as the second argument to the `update()` method.