### PR TITLE
Angular2: Pass textMaskConfig to update method

### DIFF
--- a/angular2/example/app.component.ts
+++ b/angular2/example/app.component.ts
@@ -13,6 +13,7 @@ export default class AppComponent {
 
   constructor() {
     this.mask = ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
+    this.guide = false
     this.myModel = ''
     this.modelWithValue = '5554441234'
     this.formControlInput.setValue('5555551234')

--- a/angular2/example/app.component.ts
+++ b/angular2/example/app.component.ts
@@ -10,6 +10,7 @@ export default class AppComponent {
   public modelWithValue: string
   public formControlInput: FormControl = new FormControl()
   public mask: Array<string | RegExp>
+  public guide: Boolean
 
   constructor() {
     this.mask = ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]

--- a/angular2/example/app.html
+++ b/angular2/example/app.html
@@ -6,7 +6,7 @@
         id="1"
         name="phone"
         [(ngModel)]="myModel"
-        [textMask]="{mask: mask}"
+        [textMask]="{mask: mask, guide: guide}"
         type="text"
         class="form-control"
       />
@@ -14,6 +14,8 @@
     </div>
   </div>
 
+  <input #guidecb type="checkbox" (change)="this.guide = guidecb.checked" />
+{{this.guide}}
   <div class="form-group">
     <label for="2" class="col-sm-4 control-label">
       Masked Input using <code>NgModel</code> with initial value
@@ -23,7 +25,7 @@
         id="2"
         name="phoneWithValue"
         [(ngModel)]="modelWithValue"
-        [textMask]="{mask: mask}"
+        [textMask]="{mask: mask, guide: guide}"
         type="text"
         class="form-control"
       />

--- a/angular2/example/app.html
+++ b/angular2/example/app.html
@@ -43,7 +43,7 @@
         id="3"
         name="phoneFormControl"
         [formControl]='formControlInput'
-        [textMask]="{mask: mask}"
+        [textMask]="{mask: mask, guide: guide}"
         type="text"
         class="form-control"
       />

--- a/angular2/example/app.html
+++ b/angular2/example/app.html
@@ -1,4 +1,7 @@
 <form class="form-horizontal">
+  <input #guidecb type="checkbox" (change)="this.guide = guidecb.checked" />
+  <label><code>guide</code></label>
+
   <div class="form-group">
     <label for="1" class="col-sm-4 control-label">Masked Input using <code>NgModel</code></label>
     <div class="col-sm-8 input-group">
@@ -14,9 +17,6 @@
     </div>
   </div>
 
-  <input #guidecb type="checkbox" (change)="this.guide = guidecb.checked" />
-  <label for="guidecb">Guide</label>
-  
   <div class="form-group">
     <label for="2" class="col-sm-4 control-label">
       Masked Input using <code>NgModel</code> with initial value

--- a/angular2/example/app.html
+++ b/angular2/example/app.html
@@ -15,7 +15,8 @@
   </div>
 
   <input #guidecb type="checkbox" (change)="this.guide = guidecb.checked" />
-{{this.guide}}
+  <label for="guidecb">Guide</label>
+  
   <div class="form-group">
     <label for="2" class="col-sm-4 control-label">
       Masked Input using <code>NgModel</code> with initial value

--- a/angular2/package.json
+++ b/angular2/package.json
@@ -59,6 +59,6 @@
     "zone.js": "^0.7.2"
   },
   "dependencies": {
-    "text-mask-core": "^3.1.0"
+    "text-mask-core": "^3.2.0"
   }
 }

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -45,11 +45,12 @@ export class MaskedInputDirective implements ControlValueAccessor {
       this.inputElement = this.element.nativeElement.getElementsByTagName('INPUT')[0]
     }
 
-    if (this.inputElement) {
-      this.textMaskInputElement = createTextMaskInputElement(
-          Object.assign({inputElement: this.inputElement}, this.textMaskConfig)
-      )
-    }
+    this.textMaskInputElement = createTextMaskInputElement()
+  }
+
+  update(value) {
+    this.textMaskConfig.inputElement = this.inputElement
+    this.textMaskInputElement.update(value, this.textMaskConfig)
   }
 
   writeValue(value: any) {
@@ -58,7 +59,7 @@ export class MaskedInputDirective implements ControlValueAccessor {
     }
 
     if (this.textMaskInputElement !== undefined) {
-      this.textMaskInputElement.update(value)
+      this.update(value)
     }
   }
 
@@ -72,8 +73,8 @@ export class MaskedInputDirective implements ControlValueAccessor {
     }
 
     if (this.textMaskInputElement !== undefined) {
-      this.textMaskInputElement.update(value)
       
+      this.update(value)
       // get the updated value
       value = this.inputElement.value
 

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -73,8 +73,8 @@ export class MaskedInputDirective implements ControlValueAccessor {
     }
 
     if (this.textMaskInputElement !== undefined) {
-      
       this.update(value)
+      
       // get the updated value
       value = this.inputElement.value
 

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -45,7 +45,7 @@ export class MaskedInputDirective implements ControlValueAccessor {
       this.inputElement = this.element.nativeElement.getElementsByTagName('INPUT')[0]
     }
 
-    this.textMaskInputElement = createTextMaskInputElement()
+    this.textMaskInputElement = createTextMaskInputElement({})
   }
 
   update(value) {

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -49,8 +49,7 @@ export class MaskedInputDirective implements ControlValueAccessor {
   }
 
   update(value) {
-    this.textMaskConfig.inputElement = this.inputElement
-    this.textMaskInputElement.update(value, this.textMaskConfig)
+    this.textMaskInputElement.update(value, Object.assign({inputElement: this.inputElement}, this.textMaskConfig))
   }
 
   writeValue(value: any) {


### PR DESCRIPTION
I’ve put this PR together as an example of how we _could_ make the Angular2 component “reactive”. (There are 2 ways to do this - this is one of them)

_I should point out that I don’t use Angular.. (or Typescript). The only bit of Angular code that I’ve even looked at is this (angular2-text-mask) component…. but I thought “how hard can it be…”_

Anyway.. Lets explain what I’ve done.

Instead of passing the `textMaskConfig` to the `createTextMaskInputElement` method, its now being passed into the `update` method.

```js
private setupMask() {
  // ... snip ...
  this.textMaskInputElement = createTextMaskInputElement()
}

update(value) {
  this.textMaskInputElement.update(value, Object.assign({inputElement: this.inputElement}, this.textMaskConfig))
}
```

In the example app I have added a checkbox for the `guide` property so we can try out the behaviour..

When trying the example, you will notice that when you change the config (click the `guide` checkbox), the `input` doesn't update until you next press a key.. ideally it would update instantly.. but I don't know how to make that happen in Angular.

@PerfectPixel Would you take a look at this PR, and either approve it, or use it for ideas to form your own solution for “reactivity”.