### PR TITLE
React: Pass textMaskConfig to update method

### DIFF
--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -24,7 +24,8 @@ export const MaskedInput = React.createClass({
   },
 
   update(value) {
-    this.textMaskInputElement.update(value || this.props.value, Object.assign({inputElement: this.inputElement}, this.props))
+    const textMaskConfig = Object.assign({inputElement: this.inputElement}, this.props)
+    this.textMaskInputElement.update(value || this.props.value, textMaskConfig)
   },
 
   componentDidUpdate() {

--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -19,14 +19,16 @@ export const MaskedInput = React.createClass({
   },
 
   componentDidMount() {
-    const {props, props: {value}} = this
+    this.textMaskInputElement = createTextMaskInputElement()
+    this.update()
+  },
 
-    this.textMaskInputElement = createTextMaskInputElement({inputElement: this.inputElement, ...props})
-    this.textMaskInputElement.update(value)
+  update(value) {
+    this.textMaskInputElement.update(value || this.props.value, Object.assign({inputElement: this.inputElement}, this.props))
   },
 
   componentDidUpdate() {
-    this.textMaskInputElement.update(this.props.value)
+    this.update()
   },
 
   render() {
@@ -51,7 +53,7 @@ export const MaskedInput = React.createClass({
   },
 
   onChange(event) {
-    this.textMaskInputElement.update()
+    this.update()
 
     if (typeof this.props.onChange === 'function') {
       this.props.onChange(event)


### PR DESCRIPTION
This PR does the same as #418, but for the react component.

Instead of passing the `textMaskConfig` to the `createTextMaskInputElement` method, its now being passed into the `update` method.

```js
componentDidMount() {
  this.textMaskInputElement = createTextMaskInputElement()
  this.update()
},

update(value) {
  const textMaskConfig = Object.assign({inputElement: this.inputElement}, this.props)
  this.textMaskInputElement.update(value || this.props.value, textMaskConfig)
},
```

However, I am unable to test this properly… I don’t know how to rig-up any form controls to change config settings (my knowledge of React is too little).. But I can’t see why it wouldn’t work.

@msafi could you take a look at this PR, and perhaps test it