### PR TITLE
Angular1: Pass textMaskConfig to update method

### DIFF
--- a/angular1/example/app.js
+++ b/angular1/example/app.js
@@ -23,6 +23,7 @@
     vm.modelWithValue = '5554441234'
 
     vm.textMaskConfig = {
+      guide: true,
       mask: ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
     }
   }

--- a/angular1/example/demo.html
+++ b/angular1/example/demo.html
@@ -1,4 +1,7 @@
 <form class="form-horizontal">
+  <input type="checkbox" ng-model="$ctrl.textMaskConfig.guide" />
+  <label><code>guide</code></label>
+
   <div class="form-group">
     <label for="1" class="col-sm-4 control-label">Masked Input using <code>NgModel</code></label>
     <div class="col-sm-8 input-group">

--- a/angular1/src/angular1TextMask.js
+++ b/angular1/src/angular1TextMask.js
@@ -21,17 +21,19 @@ function textMask() {
         inputElement = element[0].getElementsByTagName('INPUT')[0]
       }
 
-      var textMaskInputElement = createTextMaskInputElement(
-        Object.assign({inputElement}, scope.textMask)
-      )
+      var textMaskInputElement = createTextMaskInputElement()
+
+      function update(value) {
+        textMaskInputElement.update(value || inputElement.value, Object.assign({inputElement}, scope.textMask))
+      }
 
       element.on('blur keyup change input', function() {
-        textMaskInputElement.update(inputElement.value)
+        update()
         ngModel.$setViewValue(inputElement.value)
       })
 
       function formatter(fromModelValue) {
-        textMaskInputElement.update(fromModelValue)
+        update(fromModelValue)
         return inputElement.value
       }
 


### PR DESCRIPTION
This PR does the same as #418 for the Angular1 component.

Instead of passing the `textMaskConfig` to the `createTextMaskInputElement` method, its now being passed into the `update` method.

```js
var textMaskInputElement = createTextMaskInputElement()

function update(value) {
  textMaskInputElement.update(value || inputElement.value, Object.assign({inputElement}, scope.textMask))
}
```

Never used Angular 1 before.. I would be grateful if someone that does use Angular1 could test this out and let me know if it works or needs any changes..