### PR TITLE
Core: Make config optional

### DIFF
--- a/core/src/createTextMaskInputElement.d.ts
+++ b/core/src/createTextMaskInputElement.d.ts
@@ -1,1 +1,1 @@
-export default function createTextMaskInputElement(a: any): any
+export default function createTextMaskInputElement(a?: any): any

--- a/core/src/createTextMaskInputElement.d.ts
+++ b/core/src/createTextMaskInputElement.d.ts
@@ -1,1 +1,1 @@
-export default function createTextMaskInputElement(a?: any): any
+export default function createTextMaskInputElement(a: any): any

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -9,7 +9,7 @@ const strNone = 'none'
 const strObject = 'object'
 const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)
 
-export default function createTextMaskInputElement(config) {
+export default function createTextMaskInputElement(config = {}) {
   // Anything that we will need to keep between `update` calls, we will store in this `state` object.
   const state = {previousConformedValue: emptyString}
 


### PR DESCRIPTION
* Add a default empty object for the `config` argument in the  `createTextMaskInputElement` method.
* Update the typescript definition to allow the config to be optional