### PR TITLE
Angular2: Set the initial value for cases where the mask is disabled

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -49,6 +49,9 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
       this.setupMask()
     }
 
+    // set the initial value for cases where the mask is disabled
+    this.inputElement.value = value
+
     if (this.textMaskInputElement !== undefined) {
       this.textMaskInputElement.update(value)
     }


### PR DESCRIPTION
Set the initial value of the input element before Text Mask updates it.

This is for cases where the mask is disabled.

Fixes #393