### PR TITLE
Core: Allow update method to accept empty string

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -27,7 +27,10 @@ export default function createTextMaskInputElement(config) {
       placeholderChar = defaultPlaceholderChar,
       keepCharPositions = false
     } = config) {
-      rawValue = typeof rawValue !== 'undefined' ? rawValue : inputElement.value
+      // if `rawValue` is `undefined`, read from the `inputElement`
+      if (typeof rawValue === 'undefined') {
+        rawValue = inputElement.value
+      }
 
       // If `rawValue` equals `state.previousConformedValue`, we don't need to change anything. So, we return.
       // This check is here to handle controlled framework components that repeat the `update` call on every render.

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -27,7 +27,7 @@ export default function createTextMaskInputElement(config) {
       placeholderChar = defaultPlaceholderChar,
       keepCharPositions = false
     } = config) {
-      rawValue = rawValue || inputElement.value
+      rawValue = typeof rawValue !== 'undefined' ? rawValue : inputElement.value
 
       // If `rawValue` equals `state.previousConformedValue`, we don't need to change anything. So, we return.
       // This check is here to handle controlled framework components that repeat the `update` call on every render.

--- a/core/test/createTextMaskInputElement.spec.js
+++ b/core/test/createTextMaskInputElement.spec.js
@@ -124,6 +124,17 @@ describe('createTextMaskInputElement', () => {
       expect(inputElement.value).to.equal('')
     })
 
+    it('works when passing empty strings to the update method', () => {
+      const mask = ['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
+      const textMaskControl = createTextMaskInputElement({inputElement, mask})
+
+      textMaskControl.update(123)
+      expect(inputElement.value).to.equal('(123) ___-____')
+
+      textMaskControl.update('')
+      expect(inputElement.value).to.equal('')
+    })
+
     it('throws if given a value that it cannot work with', () => {
       const mask = ['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
       const textMaskControl = createTextMaskInputElement({inputElement, mask})

--- a/core/test/createTextMaskInputElement.spec.js
+++ b/core/test/createTextMaskInputElement.spec.js
@@ -74,6 +74,17 @@ describe('createTextMaskInputElement', () => {
       expect(inputElement.value).to.equal('(123) ___-____')
     })
 
+    it('accepts an empty string and overrides whatever value is in the input element', () => {
+      const mask = ['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
+      const textMaskControl = createTextMaskInputElement({inputElement, mask})
+
+      textMaskControl.update(123)
+      expect(inputElement.value).to.equal('(123) ___-____')
+
+      textMaskControl.update('')
+      expect(inputElement.value).to.equal('')
+    })
+
     if (!isVerify()) {
       it('does not conform given parameter if it is the same as the previousConformedValue', () => {
         const conformToMaskSpy = sinon.spy(conformToMask)
@@ -121,17 +132,6 @@ describe('createTextMaskInputElement', () => {
       expect(inputElement.value).to.equal('')
 
       textMaskControl.update(null)
-      expect(inputElement.value).to.equal('')
-    })
-
-    it('works when passing empty strings to the update method', () => {
-      const mask = ['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
-      const textMaskControl = createTextMaskInputElement({inputElement, mask})
-
-      textMaskControl.update(123)
-      expect(inputElement.value).to.equal('(123) ___-____')
-
-      textMaskControl.update('')
       expect(inputElement.value).to.equal('')
     })
 


### PR DESCRIPTION
Add a failing test

Fix #433 