### PR TITLE
Core: Allow empty strings

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -11,7 +11,7 @@ const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.
 
 export default function createTextMaskInputElement(config) {
   // Anything that we will need to keep between `update` calls, we will store in this `state` object.
-  const state = {previousConformedValue: emptyString}
+  const state = {previousConformedValue: undefined}
 
   return {
     state,

--- a/core/test/createTextMaskInputElement.spec.js
+++ b/core/test/createTextMaskInputElement.spec.js
@@ -85,6 +85,21 @@ describe('createTextMaskInputElement', () => {
       expect(inputElement.value).to.equal('')
     })
 
+    it('accepts an empty string after reinitializing text mask', () => {
+      const mask = ['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]
+      let textMaskControl = createTextMaskInputElement({inputElement, mask})
+
+      textMaskControl.update(123)
+      expect(inputElement.value).to.equal('(123) ___-____')
+
+      //reset text mask
+      textMaskControl = createTextMaskInputElement({inputElement, mask})
+
+      // now clear the value
+      textMaskControl.update('')
+      expect(inputElement.value).to.equal('')
+    })
+
     if (!isVerify()) {
       it('does not conform given parameter if it is the same as the previousConformedValue', () => {
         const conformToMaskSpy = sinon.spy(conformToMask)

--- a/react/test/reactTextMask.spec.js
+++ b/react/test/reactTextMask.spec.js
@@ -9,13 +9,17 @@ const MaskedInput = (isVerify()) ?
 describe('MaskedInput', () => {
   it('does not throw when instantiated', () => {
     expect(() => ReactTestUtils.renderIntoDocument(
-      <MaskedInput mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]} guide={true}/>
+      <MaskedInput
+      mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+      guide={true}/>
     )).not.to.throw()
   })
 
   it('renders a single input element', () => {
     const maskedInput = ReactTestUtils.renderIntoDocument(
-      <MaskedInput mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]} guide={true}/>
+      <MaskedInput
+      mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+      guide={true}/>
     )
 
     expect(

--- a/react/test/reactTextMask.spec.js
+++ b/react/test/reactTextMask.spec.js
@@ -9,13 +9,13 @@ const MaskedInput = (isVerify()) ?
 describe('MaskedInput', () => {
   it('does not throw when instantiated', () => {
     expect(() => ReactTestUtils.renderIntoDocument(
-      <MaskedInput mask='111-111' guide={true}/>
+      <MaskedInput mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]} guide={true}/>
     )).not.to.throw()
   })
 
   it('renders a single input element', () => {
     const maskedInput = ReactTestUtils.renderIntoDocument(
-      <MaskedInput mask='111-111' guide={true}/>
+      <MaskedInput mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]} guide={true}/>
     )
 
     expect(

--- a/vanilla/test/vanillaTextMask.spec.js
+++ b/vanilla/test/vanillaTextMask.spec.js
@@ -10,7 +10,7 @@ describe('inputMask', () => {
 
     expect(() => maskInput({
       inputElement,
-      mask: '111',
+      mask: ['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/],
       guide: true,
     })).not.to.throw()
   })


### PR DESCRIPTION
If #439 gets merged and the React component becomes “reactive”, then the behaviour that #437 fixed (see #433 for more info) will become broken again (for a similar but different reason).

Currently, when Text Mask is reset, the `state.previousConformedValue` is set to an empty string (`’’`).  This means that if you then try to call `update(‘’)`, the `update` will be [aborted](https://github.com/text-mask/text-mask/blob/master/core/src/createTextMaskInputElement.js#L37).

This PR changes the initial `state.previousConformedValue` to `undefined` instead of
`emptyString`.

