### PR TITLE
Maps undefined / null to empty string (fixes #435 and #448)

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -50,7 +50,8 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
     }
 
     // set the initial value for cases where the mask is disabled
-    this.inputElement.value = value
+    const normalizedValue = value == null ? '' : value
+    this.renderer.setElementProperty(this.inputElement, 'value', normalizedValue)
 
     if (this.textMaskInputElement !== undefined) {
       this.textMaskInputElement.update(value)


### PR DESCRIPTION
Mirrors the behaviour of Angular's DefaultValueAccessor (https://github.com/angular/angular/blob/2.4.8/modules/%40angular/forms/src/directives/default_value_accessor.ts#L46-L47)