### PR TITLE
Fix issue with a ghost caret blinking in the end of the input on android

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
     "dynamicTests": true,
     "isVerify": true,
     "sinon": true,
-    "getLineNumber": true
+    "getLineNumber": true,
+    "requestAnimationFrame": true
   },
   "plugins": [
     "react",

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -8,6 +8,7 @@ const emptyString = ''
 const strNone = 'none'
 const strObject = 'object'
 const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)
+const defer = typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : setTimeout
 
 export default function createTextMaskInputElement(config) {
   // Anything that we will need to keep between `update` calls, we will store in this `state` object.
@@ -172,7 +173,7 @@ export default function createTextMaskInputElement(config) {
 function safeSetSelection(element, selectionPosition) {
   if (document.activeElement === element) {
     if (isAndroid) {
-      setTimeout(() => element.setSelectionRange(selectionPosition, selectionPosition, strNone), 0)
+      defer(() => element.setSelectionRange(selectionPosition, selectionPosition, strNone), 0)
     } else {
       element.setSelectionRange(selectionPosition, selectionPosition, strNone)
     }


### PR DESCRIPTION
When typing in a masked input on android a ghost caret appears blinking at the end of the input sometimes. See gif below:

![text-mask](https://cloud.githubusercontent.com/assets/821095/24117659/d9fccf3e-0d89-11e7-9165-9971ff6eb4e3.gif)

Using requestAnimationFrame fixes it.



