### PR TITLE
Allow time to be used in `createAutoCorrectedDatePipe`

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -87,9 +87,9 @@ set to `true`.
 ```js
 import createAutoCorrectedDatePipe from 'text-mask-addons/dist/createAutoCorrectedDatePipe'
 
-const autoCorrectedDatePipe = createAutoCorrectedDatePipe('mm/dd/yyyy')
+const autoCorrectedDatePipe = createAutoCorrectedDatePipe('mm/dd/yyyy HH:MM')
 // As you can see in the line above, you can pass a string argument to `createAutoCorrectedDatePipe` 
-// to give it the order of day, month, and year in your `mask`.
+// to give it the order of day, month, year, hour and minute in your `mask`.
 
 // ...now you can pass `autoCorrectedDatePipe` to the Text Mask component as the `pipe`
 ```

--- a/addons/src/createAutoCorrectedDatePipe.js
+++ b/addons/src/createAutoCorrectedDatePipe.js
@@ -1,9 +1,9 @@
 export default function createAutoCorrectedDatePipe(dateFormat = 'mm dd yyyy') {
   return function(conformedValue) {
     const indexesOfPipedChars = []
-    const dateFormatArray = dateFormat.split(/[^dmy]+/)
-    const maxValue = {'dd': 31, 'mm': 12, 'yy': 99, 'yyyy': 9999}
-    const minValue = {'dd': 1, 'mm': 1, 'yy': 0, 'yyyy': 1}
+    const dateFormatArray = dateFormat.split(/[^dmyHMS]+/)
+    const maxValue = {'dd': 31, 'mm': 12, 'yy': 99, 'yyyy': 9999, 'HH': 24, 'MM': 59, 'SS': 59}
+    const minValue = {'dd': 1, 'mm': 1, 'yy': 0, 'yyyy': 1, 'HH': 0, 'MM': 0, 'SS': 0}
     const conformedValueArr = conformedValue.split('')
 
     // Check first digit

--- a/addons/test/createAutoCorrectedDatePipe.spec.js
+++ b/addons/test/createAutoCorrectedDatePipe.spec.js
@@ -48,4 +48,62 @@ describe('createAutoCorrectedDatePipe', () => {
     let pipe = createAutoCorrectedDatePipe('mm dd yy')
     expect(pipe('12 31 00')).to.deep.equal({value: '12 31 00', indexesOfPipedChars: []})
   })
+
+  describe('datetime', () => {
+    let autoCorrectedDateTimePipe
+
+    it('accepts the date time format as the first parameter and returns a date time pipe function', () => {
+      autoCorrectedDateTimePipe = createAutoCorrectedDatePipe('mm dd yyyy HH MM SS')
+    })
+
+    it('completes the hours if the 1st digit is bigger than 2 and returns `indexesOfPipedChars`', () => {
+      expect(autoCorrectedDateTimePipe('12/31/9999 1')).to.deep.equal({value: '12/31/9999 1', indexesOfPipedChars: []})
+      expect(autoCorrectedDateTimePipe('12/31/9999 2')).to.deep.equal({value: '12/31/9999 2', indexesOfPipedChars: []})
+      expect(
+        autoCorrectedDateTimePipe('12/31/9999 3'))
+          .to.deep.equal({value: '12/31/9999 03', indexesOfPipedChars: [11]}
+      )
+    })
+
+    it('returns false if hours 1st digit is 2 and 2nd digit is bigger than 4', () => {
+      expect(autoCorrectedDateTimePipe('12/31/9999 25')).to.equal(false)
+    })
+
+    it('completes the minutes if the 1st digit is bigger than 5 and returns `indexesOfPipedChars`', () => {
+      expect(
+        autoCorrectedDateTimePipe('12/31/9999 24:5'))
+          .to.deep.equal({value: '12/31/9999 24:5', indexesOfPipedChars: []}
+      )
+      expect(
+        autoCorrectedDateTimePipe('12/31/9999 24:6'))
+          .to.deep.equal({value: '12/31/9999 24:06', indexesOfPipedChars: [14]}
+      )
+    })
+
+    it('returns false if minutes 1st digit is 6 and 2nd digit is 0', () => {
+      expect(autoCorrectedDateTimePipe('12/31/9999 24:60')).to.equal(false)
+    })
+
+    it('completes the seconds if the 1st digit is bigger than 5 and returns `indexesOfPipedChars`', () => {
+      expect(
+        autoCorrectedDateTimePipe('12/31/9999 24:59:5'))
+          .to.deep.equal({value: '12/31/9999 24:59:5', indexesOfPipedChars: []}
+      )
+      expect(
+        autoCorrectedDateTimePipe('12/31/9999 24:59:6'))
+          .to.deep.equal({value: '12/31/9999 24:59:06', indexesOfPipedChars: [17]}
+      )
+    })
+
+    it('returns false if seconds 1st digit is 6 and 2nd digit is 0', () => {
+      expect(autoCorrectedDateTimePipe('12/31/9999 24:59:60')).to.equal(false)
+    })
+
+    it('returns unmodified partial entry if it could develop to correct date', () => {
+      expect(
+        autoCorrectedDateTimePipe('0 /  /     :  :  '))
+          .to.deep.equal({value: '0 /  /     :  :  ', indexesOfPipedChars: []}
+      )
+    })
+  })
 })


### PR DESCRIPTION
This is a follow-up of #580, which got feedback a month ago but wasn't implemented. So credits to @FacundoGFlores.

The main change I made compared to #580, is that it now uses the existing `createAutoCorrectedDatePipe`. Also, it uses `HH:MM` as syntax for time instead of `hh:mm`. This is because otherwise it would interfere with `mm`, which is already used for months. Lastly I added a little documentation for this feature to the README.

Fixes #490