### PR TITLE
Slight temporary fix for broken setSelectionRange on types like email…

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -176,11 +176,16 @@ export default function createTextMaskInputElement(config) {
 
 function safeSetSelection(element, selectionPosition) {
   if (document.activeElement === element) {
+    // Fix for setSelectionRange not working on types other than these in some modern browsers:
+    let _type = element.type.slice();
+    if (_type !== 'text' && _type !== 'search' && _type !== 'url' && _type !== 'tel' && _type !== 'password')
+      element.type = 'text';
     if (isAndroid) {
       defer(() => element.setSelectionRange(selectionPosition, selectionPosition, strNone), 0)
     } else {
       element.setSelectionRange(selectionPosition, selectionPosition, strNone)
     }
+    element.type = _type;
   }
 }
 


### PR DESCRIPTION
… and number...

The thing is that on some modern browsers (chrome, mainly) `setSelectionRange` doesn't work on type email, number and some others. Here's a quick fix for this, until better solution is found.