### PR TITLE
issue-671 `createNumberMask` integer limit doesn't work when we enter negative (minus) value

### DIFF
--- a/addons/src/createNumberMask.js
+++ b/addons/src/createNumberMask.js
@@ -40,10 +40,15 @@ export default function createNumberMask({
     ) {
       return prefix.split(emptyString).concat(['0', decimalSymbol, digitRegExp]).concat(suffix.split(emptyString))
     }
+    
+    const isNegative = (rawValue[0] === minus) && allowNegative
+    //If negative remove "-" sign
+    if(isNegative){
+      rawValue = rawValue.toString().substr(1);
+    }
 
     const indexOfLastDecimal = rawValue.lastIndexOf(decimalSymbol)
     const hasDecimal = indexOfLastDecimal !== -1
-    const isNegative = (rawValue[0] === minus) && allowNegative
 
     let integer
     let fraction

--- a/addons/src/createNumberMask.js
+++ b/addons/src/createNumberMask.js
@@ -40,11 +40,11 @@ export default function createNumberMask({
     ) {
       return prefix.split(emptyString).concat(['0', decimalSymbol, digitRegExp]).concat(suffix.split(emptyString))
     }
-    
+
     const isNegative = (rawValue[0] === minus) && allowNegative
     //If negative remove "-" sign
-    if(isNegative){
-      rawValue = rawValue.toString().substr(1);
+    if(isNegative) {
+      rawValue = rawValue.toString().substr(1)
     }
 
     const indexOfLastDecimal = rawValue.lastIndexOf(decimalSymbol)


### PR DESCRIPTION
`createNumberMask` integer limit doesn't work when we enter negative (minus) value.

If we have set integerLimit to 16 digit and also allowed negative value (allowNegative). If we enter value in negative it only allow to enter 14 digit instead of 16. If we enter positive value (without - sign) it allows to enter 16 digit.