### PR TITLE
[text-mask-addons/createNumberMask] Added support for minValue, maxValue

### DIFF
--- a/addons/src/createNumberMask.js
+++ b/addons/src/createNumberMask.js
@@ -20,13 +20,15 @@ export default function createNumberMask({
   requireDecimal = false,
   allowNegative = false,
   allowLeadingZeroes = false,
-  integerLimit = null
+  integerLimit = null,
+  maxValue = Number.POSITIVE_INFINITY,
+  minValue = Number.NEGATIVE_INFINITY
 } = {}) {
   const prefixLength = prefix && prefix.length || 0
   const suffixLength = suffix && suffix.length || 0
   const thousandsSeparatorSymbolLength = thousandsSeparatorSymbol && thousandsSeparatorSymbol.length || 0
 
-  function numberMask(rawValue = emptyString) {
+  function numberMask(rawValue = emptyString, metaData) {
     const rawValueLength = rawValue.length
 
     if (
@@ -51,6 +53,7 @@ export default function createNumberMask({
     const hasDecimal = indexOfLastDecimal !== -1
 
     let integer
+    let rawFraction
     let fraction
     let mask
 
@@ -62,8 +65,8 @@ export default function createNumberMask({
     if (hasDecimal && (allowDecimal || requireDecimal)) {
       integer = rawValue.slice(rawValue.slice(0, prefixLength) === prefix ? prefixLength : 0, indexOfLastDecimal)
 
-      fraction = rawValue.slice(indexOfLastDecimal + 1, rawValueLength)
-      fraction = convertToMask(fraction.replace(nonDigitsRegExp, emptyString))
+      rawFraction = rawValue.slice(indexOfLastDecimal + 1, rawValueLength)
+      fraction = convertToMask(rawFraction.replace(nonDigitsRegExp, emptyString))
     } else {
       if (rawValue.slice(0, prefixLength) === prefix) {
         integer = rawValue.slice(prefixLength)
@@ -83,6 +86,13 @@ export default function createNumberMask({
 
     if (!allowLeadingZeroes) {
       integer = integer.replace(/^0+(0$|[^0])/, '$1')
+    }
+    
+    var value = parseFloat(integer + '.' + rawFraction);
+    if (value > maxValue) {
+      return numberMask(metaData.previousConformedValue);
+    } else if (value < minValue) {
+      return numberMask(metaData.previousConformedValue);
     }
 
     integer = (includeThousandsSeparator) ? addThousandsSeparator(integer, thousandsSeparatorSymbol) : integer


### PR DESCRIPTION
Seems like a logical addition to add a minimum and maximum value to define a range. For example you could define a percent mask as such:

```  
percentMask = createNumberMask({
    prefix: '',
    postfix: '%',
    allowDecimal: true,
    integerLimit: 3,
    maxValue: 100,
    minValue: 0
}); 
```

You don't need to include the pull request though, there are probably better ways to go about it than running the previous value through the mask function again when the value is too small/large.
