### PR TITLE
Fix issue with VueJS mask reactivity

### DIFF
--- a/vue/src/vueTextMask.js
+++ b/vue/src/vueTextMask.js
@@ -83,9 +83,9 @@ export default {
   },
 
   watch: {
-    mask(newMask) {
+    mask(newMask, oldMask) {
       // Check if the mask has changed (Vue cannot detect whether an array has changed)
-      if (this.mask !== newMask) {
+      if (this.mask !== oldMask) {
         this.bind()
       }
     },


### PR DESCRIPTION
When mask is updated dynamically, bind is not called since `newMask` is the same as `this.mask` value on the watcher which was already updated via prop.
The comparison should be done against mask's old value.