### PR TITLE
Special case value deletion with a leading decimal

### DIFF
--- a/core/src/conformToMask.js
+++ b/core/src/conformToMask.js
@@ -218,6 +218,8 @@ export default function conformToMask(rawValue = emptyString, mask = emptyString
     if (indexOfLastFilledPlaceholderChar !== null) {
       // We substring from the beginning until the position after the last filled placeholder char.
       conformedValue = conformedValue.substr(0, indexOfLastFilledPlaceholderChar + 1)
+    } else if (rawValue === '.') {
+      conformedValue = '0.'
     } else {
       // If we couldn't find `indexOfLastFilledPlaceholderChar` that means the user deleted
       // the first character in the mask. So we return an empty string.

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -142,7 +142,7 @@ export default function createTextMaskInputElement(config) {
       // After determining the conformed value, we will need to know where to set
       // the caret position. `adjustCaretPosition` will tell us.
       const adjustedCaretPosition = adjustCaretPosition({
-        previousConformedValue,
+        previousConformedValue: safeRawValue === '.' ? '' : previousConformedValue,
         previousPlaceholder,
         conformedValue: finalConformedValue,
         placeholder,


### PR DESCRIPTION
This maybe fixes #740

Leading decimals are [handled by createNumberMask](https://github.com/text-mask/text-mask/blob/master/addons/src/createNumberMask.js#L37-L41) to substitute a placeholder of `0.`

This works fine for new values, and most edits. But if I replace a value with a dot, the field remains empty for one update cycle. Another dot and it's back on track.

The likelier UX scenario for a non-prefixed decimal value is going to be _dot_ → _number_. Entering this with just one dot and we end up with a whole number. `9%` versus the user's intent of `0.9%` — huge difference in most contexts!

![example](http://g.recordit.co/PDWSMqmKw9.gif)

I tried my best to track down where this behavior is implemented and the issue seems to be the result of assumptions around character-for-character placeholders versus _two_ characters for one raw value in this case.

_Specifically:_

https://github.com/text-mask/text-mask/blob/master/core/src/adjustCaretPosition.js#L25

`.` means this goes negative, so `isAddition` is false and the caret moves to the beginning. So I set the previousConform value to `''` as it is effectively an empty value in this scenario.

https://github.com/text-mask/text-mask/blob/master/core/src/conformToMask.js#L211-L216

The `0._` placeholder is longer than the conformed `0.` value, so we stop short of the placeholder character index.

I'm not sure the leading decimal case is special enough to warrant these exceptions, but I couldn't think of another case where a placeholder would be expanded like this.

If this is the wrong direction I can make another attempt with some feedback, thanks!