### PR TITLE
Add onBlur support to react-text-mask

### DIFF
--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -57,6 +57,12 @@ export default class MaskedInput extends React.Component {
       this.props.onChange(event)
     }
   }
+
+  onBlur(event) {
+    if (typeof this.props.onBlur === 'function') {
+      this.props.onBlur(event)
+    }
+  }
 }
 
 MaskedInput.propTypes = {

--- a/react/test/reactTextMask.spec.js
+++ b/react/test/reactTextMask.spec.js
@@ -271,6 +271,22 @@ describe('MaskedInput', () => {
     expect(maskedInput.textMaskInputElement.update.callCount).to.equal(1)
   })
 
+  it('calls props.onBlur when a change event is received', () => {
+    const onBlurSpy = sinon.spy((event) => {
+      expect(event.target.value).to.equal('(123) ___-____')
+    })
+    const maskedInput = ReactTestUtils.renderIntoDocument(
+      <MaskedInput
+        value='123'
+        onBlur={onBlurSpy}
+        mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+        guide={true}/>
+    )
+    const renderedDOMComponent = ReactTestUtils.findRenderedDOMComponentWithTag(maskedInput, 'input')
+    ReactTestUtils.Simulate.blur(renderedDOMComponent)
+    expect(onBlurSpy.callCount).to.equal(1)
+  })
+
   it('calls textMaskInputElement.update when an input event is received when props.onChange is not set', () => {
     const maskedInput = ReactTestUtils.renderIntoDocument(
       <MaskedInput


### PR DESCRIPTION
## Description 
Adds support for `onBlur` to `react-text-mask`. 

```jsx
<MaskedInput
  mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
  className='form-control'
  id='1'
  type='text'
  onBlur={(event) => alert(event)}
/>
```