### PR TITLE
conformToMask: accept mask functions

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -89,7 +89,7 @@ The `update` method should be called every time the `inputElement.value` changes
 This function takes three arguments:
 
 * rawValue (string): the string value that you want to conform to the mask
-* mask (array): the mask to which you want the string to conform. You can find
+* mask (array or function): the mask to which you want the string to conform. You can find
 [mask documentation here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme).
 * config (object): config object. See below for details
 

--- a/core/src/conformToMask.js
+++ b/core/src/conformToMask.js
@@ -17,7 +17,6 @@ export default function conformToMask(rawValue = emptyString, mask = emptyArray,
       // mask functions can setup caret traps to have some control over how the caret moves. We need to process
       // the mask for any caret traps. `processCaretTraps` will remove the caret traps from the mask
       mask = processCaretTraps(mask).maskWithoutCaretTraps
-
     } else {
       throw new Error(
         'Text-mask:conformToMask; The mask property must be an array.'

--- a/core/src/conformToMask.js
+++ b/core/src/conformToMask.js
@@ -1,14 +1,28 @@
-import {convertMaskToPlaceholder, isArray} from './utilities'
-import {placeholderChar as defaultPlaceholderChar} from './constants'
+import {convertMaskToPlaceholder, isArray, processCaretTraps} from './utilities'
+import {placeholderChar as defaultPlaceholderChar, strFunction} from './constants'
 
 const emptyArray = []
 const emptyString = ''
 
 export default function conformToMask(rawValue = emptyString, mask = emptyArray, config = {}) {
   if (!isArray(mask)) {
-    throw new Error(
-      'Text-mask:conformToMask; The mask property must be an array.'
-    )
+    // If someone passes a function as the mask property, we should call the
+    // function to get the mask array - Normally this is handled by the
+    // `createTextMaskInputElement:update` function - this allows mask functions
+    // to be used directly with `conformToMask`
+    if (typeof mask === strFunction) {
+      // call the mask function to get the mask array
+      mask = mask(rawValue, config)
+
+      // mask functions can setup caret traps to have some control over how the caret moves. We need to process
+      // the mask for any caret traps. `processCaretTraps` will remove the caret traps from the mask
+      mask = processCaretTraps(mask).maskWithoutCaretTraps
+
+    } else {
+      throw new Error(
+        'Text-mask:conformToMask; The mask property must be an array.'
+      )
+    }
   }
 
   // These configurations tell us how to conform the mask

--- a/core/src/constants.js
+++ b/core/src/constants.js
@@ -1,1 +1,2 @@
 export const placeholderChar = '_'
+export const strFunction = 'function'

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -1,9 +1,8 @@
 import adjustCaretPosition from './adjustCaretPosition'
 import conformToMask from './conformToMask'
 import {convertMaskToPlaceholder, isString, isNumber, processCaretTraps} from './utilities'
-import {placeholderChar as defaultPlaceholderChar} from './constants'
+import {placeholderChar as defaultPlaceholderChar, strFunction} from './constants'
 
-const strFunction = 'function'
 const emptyString = ''
 const strNone = 'none'
 const strObject = 'object'

--- a/core/test/conformToMask.spec.js
+++ b/core/test/conformToMask.spec.js
@@ -18,12 +18,13 @@ const testInputs = ['rawValue', 'mask', 'previousConformedValue', 'currentCaretP
 
 describe('conformToMask', () => {
   it('throws if mask is not an array or function', () => {
-    expect(() => conformToMask('', false)).to.throw('Text-mask:conformToMask; The mask property must be an array.')
-    expect(() => conformToMask('', true)).to.throw('Text-mask:conformToMask; The mask property must be an array.')
-    expect(() => conformToMask('', 'abc')).to.throw('Text-mask:conformToMask; The mask property must be an array.')
-    expect(() => conformToMask('', 123)).to.throw('Text-mask:conformToMask; The mask property must be an array.')
-    expect(() => conformToMask('', null)).to.throw('Text-mask:conformToMask; The mask property must be an array.')
-    expect(() => conformToMask('', {})).to.throw('Text-mask:conformToMask; The mask property must be an array.')
+    const err = 'Text-mask:conformToMask; The mask property must be an array.'
+    expect(() => conformToMask('', false)).to.throw(err)
+    expect(() => conformToMask('', true)).to.throw(err)
+    expect(() => conformToMask('', 'abc')).to.throw(err)
+    expect(() => conformToMask('', 123)).to.throw(err)
+    expect(() => conformToMask('', null)).to.throw(err)
+    expect(() => conformToMask('', {})).to.throw(err)
   })
 
   describe('Accepted character in mask', () => {

--- a/core/test/conformToMask.spec.js
+++ b/core/test/conformToMask.spec.js
@@ -158,13 +158,6 @@ describe('conformToMask', () => {
       expect(maskSpy.callCount).to.equal(1)
     })
 
-    it('processes the result of the mask function and removes caretTraps', () => {
-      const mask = () => [/\d/, /\d/, '[]', '.', '[]', /\d/, /\d/]
-      const result = conformToMask('2', mask)
-
-      expect(result.conformedValue).to.equal('2_.__')
-    })
-
     it('passes the rawValue to the mask function', () => {
       const mask = (value) => {
         expect(typeof value).to.equal('string')
@@ -193,6 +186,13 @@ describe('conformToMask', () => {
       })
 
       expect(result.conformedValue).to.equal('12__')
+    })
+
+    it('processes the result of the mask function and removes caretTraps', () => {
+      const mask = () => [/\d/, /\d/, '[]', '.', '[]', /\d/, /\d/]
+      const result = conformToMask('2', mask)
+
+      expect(result.conformedValue).to.equal('2_.__')
     })
 
     dynamicTests(

--- a/core/test/utilities.spec.js
+++ b/core/test/utilities.spec.js
@@ -1,5 +1,16 @@
-import {processCaretTraps} from '../src/utilities'
+import {convertMaskToPlaceholder, processCaretTraps} from '../src/utilities'
 
+describe('convertMaskToPlaceholder', () => {
+  it('throws if mask is not an array', () => {
+    expect(() => convertMaskToPlaceholder(false)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    expect(() => convertMaskToPlaceholder(true)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    expect(() => convertMaskToPlaceholder('abc')).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    expect(() => convertMaskToPlaceholder(123)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    expect(() => convertMaskToPlaceholder(null)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    expect(() => convertMaskToPlaceholder({})).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    expect(() => convertMaskToPlaceholder(() => {})).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+  })
+})
 describe('processCaretTraps', () => {
   it('returns the mask without caret traps and the caret trap indexes', () => {
     const mask = ['$', /\d/, /\d/, /\d/, /\d/, '.', '[]', /\d/, /\d/]

--- a/core/test/utilities.spec.js
+++ b/core/test/utilities.spec.js
@@ -2,13 +2,14 @@ import {convertMaskToPlaceholder, processCaretTraps} from '../src/utilities'
 
 describe('convertMaskToPlaceholder', () => {
   it('throws if mask is not an array', () => {
-    expect(() => convertMaskToPlaceholder(false)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
-    expect(() => convertMaskToPlaceholder(true)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
-    expect(() => convertMaskToPlaceholder('abc')).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
-    expect(() => convertMaskToPlaceholder(123)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
-    expect(() => convertMaskToPlaceholder(null)).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
-    expect(() => convertMaskToPlaceholder({})).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
-    expect(() => convertMaskToPlaceholder(() => {})).to.throw('Text-mask:convertMaskToPlaceholder; The mask property must be an array.')
+    const err = 'Text-mask:convertMaskToPlaceholder; The mask property must be an array.'
+    expect(() => convertMaskToPlaceholder(false)).to.throw(err)
+    expect(() => convertMaskToPlaceholder(true)).to.throw(err)
+    expect(() => convertMaskToPlaceholder('abc')).to.throw(err)
+    expect(() => convertMaskToPlaceholder(123)).to.throw(err)
+    expect(() => convertMaskToPlaceholder(null)).to.throw(err)
+    expect(() => convertMaskToPlaceholder({})).to.throw(err)
+    expect(() => convertMaskToPlaceholder(() => {})).to.throw(err)
   })
 })
 describe('processCaretTraps', () => {


### PR DESCRIPTION
This PR add support for mask functions to be passed into the [`conformToMask` function](https://github.com/text-mask/text-mask/blob/master/core/src/conformToMask.js).