### PR TITLE
Type textMaskConfig

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -23,11 +23,12 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
 
   @Input('textMask')
   textMaskConfig = {
-    mask: [],
-    guide: true,
-    placeholderChar: '_',
-    pipe: undefined,
-    keepCharPositions: false,
+    mask: <Array<string | RegExp> | ((raw: string) => Array<string | RegExp>) | boolean> [],
+    guide: <boolean> true,
+    placeholderChar: <string> '_',
+    pipe: <Function> undefined,
+    keepCharPositions: <boolean> false,
+    showMask: <boolean> false
   }
 
   _onTouched = () => {}


### PR DESCRIPTION
Put types on the properties of textMaskConfig. 

This allows, for example,, the MaskedInputDirective to be extended and wrapped by a directive that will access textMaskConfig without the mediation of a template. This way errors can be avoided when assigning a boolean or a function to textMaskConfig.mask, and showMask can be assigned as well.