### PR TITLE
update angular text-mask directive

### DIFF
--- a/angular2/package.json
+++ b/angular2/package.json
@@ -35,15 +35,14 @@
     "string formatting"
   ],
   "devDependencies": {
-    "@angular/common": "^2.1.2",
-    "@angular/compiler": "^2.1.2",
-    "@angular/compiler-cli": "^2.1.2",
-    "@angular/core": "^2.1.2",
-    "@angular/forms": "^2.1.2",
-    "@angular/http": "^2.1.2",
-    "@angular/platform-browser": "^2.1.2",
-    "@angular/platform-browser-dynamic": "^2.1.2",
-    "@angular/platform-server": "^2.1.2",
+    "@angular/common": "^4.0.0",
+    "@angular/compiler": "^4.0.0",
+    "@angular/compiler-cli": "^4.0.0",
+    "@angular/core": "^4.0.0",
+    "@angular/forms": "^4.0.0",
+    "@angular/http": "^4.0.0",
+    "@angular/platform-browser": "^4.0.0",
+    "@angular/platform-browser-dynamic": "^4.0.0",
     "@types/core-js": "^0.9.34",
     "@types/jasmine": "^2.5.52",
     "@types/node": "^6.0.45",
@@ -62,8 +61,8 @@
     "systemjs": "0.19.39",
     "ts-node": "~1.2.0",
     "tslint": "^3.13.0",
-    "typescript": "~2.3.0",
-    "zone.js": "^0.7.2"
+    "typescript": "~2.7.0",
+    "zone.js": "^0.8.4"
   },
   "dependencies": {
     "text-mask-core": "^5.0.0"

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -1,6 +1,16 @@
-import { Directive, ElementRef, forwardRef, Input, Inject, NgModule, OnChanges, Provider, Renderer, SimpleChanges } from '@angular/core'
-import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms'
+import { Directive, ElementRef, forwardRef, Input, Inject, NgModule, OnChanges, Optional, Provider, Renderer2, SimpleChanges } from '@angular/core'
+import { NG_VALUE_ACCESSOR, ControlValueAccessor, COMPOSITION_BUFFER_MODE } from '@angular/forms'
+import {ɵgetDOM as getDOM} from '@angular/platform-browser'
 import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore'
+
+export class TextMaskConfig {
+  mask: Array<string | RegExp> | ((raw: string) => Array<string | RegExp>) | false
+  guide?: boolean
+  placeholderChar?: string
+  pipe?: (conformedValue: string, config: TextMaskConfig) => false | string | object
+  keepCharPositions?: boolean
+  showMask?: boolean
+}
 
 export const MASKEDINPUT_VALUE_ACCESSOR: Provider = {
   provide: NG_VALUE_ACCESSOR,
@@ -8,21 +18,28 @@ export const MASKEDINPUT_VALUE_ACCESSOR: Provider = {
   multi: true
 }
 
+/**
+ * We must check whether the agent is Android because composition events
+ * behave differently between iOS and Android.
+ */
+function _isAndroid(): boolean {
+  const userAgent = getDOM() ? getDOM().getUserAgent() : ''
+  return /android (\d+)/.test(userAgent.toLowerCase())
+}
+
 @Directive({
   host: {
-    '(input)': 'onInput($event.target.value)',
-    '(blur)': '_onTouched()'
+    '(input)': '_handleInput($event.target.value)',
+    '(blur)': 'onTouched()',
+    '(compositionstart)': '_compositionStart()',
+    '(compositionend)': '_compositionEnd($event.target.value)'
   },
   selector: '[textMask]',
   exportAs: 'textMask',
   providers: [MASKEDINPUT_VALUE_ACCESSOR]
 })
 export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
-  private textMaskInputElement: any
-  private inputElement: HTMLInputElement
-
-  @Input('textMask')
-  textMaskConfig = {
+  @Input('textMask') textMaskConfig: TextMaskConfig = {
     mask: [],
     guide: true,
     placeholderChar: '_',
@@ -30,58 +47,74 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
     keepCharPositions: false,
   }
 
-  _onTouched = () => {}
-  _onChange = (_: any) => {}
+  onChange = (_: any) => {}
+  onTouched = () => {}
 
-  constructor(@Inject(Renderer) private renderer: Renderer, @Inject(ElementRef) private element: ElementRef) {}
+  private textMaskInputElement: any
+  private inputElement: HTMLInputElement
+
+  /** Whether the user is creating a composition string (IME events). */
+  private _composing = false
+
+  constructor(
+    private _renderer: Renderer2,
+    private _elementRef: ElementRef,
+    @Optional() @Inject(COMPOSITION_BUFFER_MODE)private _compositionMode: boolean
+  ) {
+    if (this._compositionMode == null) {
+      this._compositionMode = !_isAndroid()
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges) {
-    this.setupMask(true)
+    this._setupMask(true)
     if (this.textMaskInputElement !== undefined) {
       this.textMaskInputElement.update(this.inputElement.value)
     }
   }
 
   writeValue(value: any) {
-    this.setupMask()
+    this._setupMask()
 
     // set the initial value for cases where the mask is disabled
     const normalizedValue = value == null ? '' : value
-    this.renderer.setElementProperty(this.inputElement, 'value', normalizedValue)
+    this._renderer.setProperty(this.inputElement, 'value', normalizedValue)
 
     if (this.textMaskInputElement !== undefined) {
       this.textMaskInputElement.update(value)
     }
   }
 
-  registerOnChange(fn: (value: any) => any): void { this._onChange = fn }
+  registerOnChange(fn: (_: any) => void): void { this.onChange = fn }
+  registerOnTouched(fn: () => void): void { this.onTouched = fn }
 
-  registerOnTouched(fn: () => any): void { this._onTouched = fn }
-
-  setDisabledState(isDisabled: boolean) {
-    this.renderer.setElementProperty(this.element.nativeElement, 'disabled', isDisabled)
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled)
   }
+
   
-  onInput(value) {
-    this.setupMask()
+  _handleInput(value) {
+    if (!this._compositionMode || (this._compositionMode && !this._composing)) {
+      this._setupMask()
 
-    if (this.textMaskInputElement !== undefined) {
-      this.textMaskInputElement.update(value)
-      
-      // get the updated value
-      value = this.inputElement.value
-      this._onChange(value)
+      if (this.textMaskInputElement !== undefined) {
+        this.textMaskInputElement.update(value)
+        
+        // get the updated value
+        value = this.inputElement.value
+        this.onChange(value)
+      }
     }
   }
 
-  private setupMask(create = false) {
+  _setupMask(create = false) {
     if (!this.inputElement) {
-      if (this.element.nativeElement.tagName.toUpperCase() === 'INPUT') {
+      if (this._elementRef.nativeElement.tagName.toUpperCase() === 'INPUT') {
         // `textMask` directive is used directly on an input element
-        this.inputElement = this.element.nativeElement
+        this.inputElement = this._elementRef.nativeElement
       } else {
         // `textMask` directive is used on an abstracted input element, `md-input-container`, etc
-        this.inputElement = this.element.nativeElement.getElementsByTagName('INPUT')[0]
+        this.inputElement = this._elementRef.nativeElement.getElementsByTagName('INPUT')[0]
       }
     }
     
@@ -91,6 +124,13 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
       )
     }
     
+  }
+
+  _compositionStart(): void { this._composing = true }
+
+  _compositionEnd(value: any): void {
+    this._composing = false
+    this._compositionMode && this._handleInput(value)
   }
 }
 

--- a/angular2/test/angular2TextMask.spec.ts
+++ b/angular2/test/angular2TextMask.spec.ts
@@ -2,7 +2,7 @@ import { MaskedInputDirective } from '../src/angular2TextMask'
 
 describe('MaskedInputDirective', () => {
   it('should create an instance', () => {
-    const directive = new MaskedInputDirective(null, null)
+    const directive = new MaskedInputDirective(null, null, false)
     expect(directive).toBeTruthy()
   })
 })


### PR DESCRIPTION
Brings the directive in line with angular 4.0.0, most notably enables composition events (might resolve #524).
Adds type definitions for the config (resolves #773).
Replaces the deprecated `Renderer`.

@lozjackson I recommend to use scoped packages in npm at some point and properly rename this package to `@text-mask/angular`