### PR TITLE
Issue #456: Adding min max year to AutoCorrectedDatePipe

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -77,6 +77,9 @@ day slots.
 
 It also blocks the user from entering invalid days or months such as `33/44`.
 
+You may also specify a `minYear` and a `maxYear` to prevent users from typing dates outside of that specified range.
+If the user enters a number outside of the range you specified, it will block the input.
+
 For `createAutoCorrectedDatePipe` to work properly, the Text Mask component needs to be
 configured with
 [`keepCharPositions`](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#keepcharpositions)

--- a/addons/src/createAutoCorrectedDatePipe.js
+++ b/addons/src/createAutoCorrectedDatePipe.js
@@ -1,9 +1,9 @@
-export default function createAutoCorrectedDatePipe(dateFormat = 'mm dd yyyy') {
+export default function createAutoCorrectedDatePipe(dateFormat = 'mm dd yyyy', minYear = 0, maxYear = 9999) {
   return function(conformedValue) {
     const indexesOfPipedChars = []
     const dateFormatArray = dateFormat.split(/[^dmyHMS]+/)
-    const maxValue = {'dd': 31, 'mm': 12, 'yy': 99, 'yyyy': 9999, 'HH': 23, 'MM': 59, 'SS': 59}
-    const minValue = {'dd': 1, 'mm': 1, 'yy': 0, 'yyyy': 1, 'HH': 0, 'MM': 0, 'SS': 0}
+    const maxValue = {'dd': 31, 'mm': 12, 'yy': 99, 'yyyy': maxYear, 'HH': 23, 'MM': 59, 'SS': 59}
+    const minValue = {'dd': 1, 'mm': 1, 'yy': 0, 'yyyy': minYear, 'HH': 0, 'MM': 0, 'SS': 0}
     const conformedValueArr = conformedValue.split('')
 
     // Check first digit
@@ -24,7 +24,11 @@ export default function createAutoCorrectedDatePipe(dateFormat = 'mm dd yyyy') {
       const length = format.length
       const textValue = conformedValue.substr(position, length).replace(/\D/g, '')
       const value = parseInt(textValue, 10)
-
+      if (format === 'yyyy') {
+        const scopedMaxValue = parseInt(maxValue[format].toString().substring(0, textValue.length), 10)
+        const scopedMinValue = parseInt(minValue[format].toString().substring(0, textValue.length), 10)
+        return value < scopedMinValue || value > scopedMaxValue
+      }
       return value > maxValue[format] || (textValue.length === length && value < minValue[format])
     })
 

--- a/addons/test/createAutoCorrectedDatePipe.spec.js
+++ b/addons/test/createAutoCorrectedDatePipe.spec.js
@@ -106,4 +106,71 @@ describe('createAutoCorrectedDatePipe', () => {
       )
     })
   })
+  describe('createAutoCorrectDatePipe with min year', () => {
+    let autoCorrectedDateTimePipe
+
+    it('accepts minimum year as the second parameter and returns a date time pipe function', () => {
+      autoCorrectedDateTimePipe = createAutoCorrectedDatePipe('mm dd yyyy', 1999)
+    })
+
+    it('returns false if year 1st digit is less than 1', () => {
+      expect(autoCorrectedDateTimePipe('12/31/0')).to.equal(false)
+    })
+
+    it('returns false if year 2st digit is less than 9', () => {
+      expect(autoCorrectedDateTimePipe('12/31/18')).to.equal(false)
+    })
+
+    it('returns false if year 3rd digit is less than 9', () => {
+      expect(autoCorrectedDateTimePipe('12/31/198')).to.equal(false)
+    })
+
+    it('returns false if year 4th digit is less than 9', () => {
+      expect(autoCorrectedDateTimePipe('12/31/1998')).to.equal(false)
+    })
+
+    it('allows for min year', () => {
+      let pipe = createAutoCorrectedDatePipe('mm dd yyyy', 1999)
+      expect(pipe('12 31 1999')).to.deep.equal({value: '12 31 1999', indexesOfPipedChars: []})
+    })
+  })
+
+  describe('createAutoCorrectDatePipe with min and max year', () => {
+    let autoCorrectedDateTimePipe
+
+    it('accepts min and max year as the second/third parameter and returns a date time pipe function', () => {
+      autoCorrectedDateTimePipe = createAutoCorrectedDatePipe('mm dd yyyy', 1990, 2020)
+    })
+
+    it('returns false if year 1st digit is more than 2', () => {
+      expect(autoCorrectedDateTimePipe('12/31/3')).to.equal(false)
+    })
+
+    it('returns false if year 2st digit is more than 0', () => {
+      expect(autoCorrectedDateTimePipe('12/31/21')).to.equal(false)
+    })
+
+    it('returns false if year 3rd digit is more than 2', () => {
+      expect(autoCorrectedDateTimePipe('12/31/203')).to.equal(false)
+    })
+
+    it('returns false if year 4th digit is more than 0', () => {
+      expect(autoCorrectedDateTimePipe('12/31/2021')).to.equal(false)
+    })
+
+    it('allows for a year at the top side of the range', () => {
+      let pipe = createAutoCorrectedDatePipe('mm dd yyyy', 1990, 2020)
+      expect(pipe('12 31 2020')).to.deep.equal({value: '12 31 2020', indexesOfPipedChars: []})
+    })
+
+    it('allows for a year within the range', () => {
+      let pipe = createAutoCorrectedDatePipe('mm dd yyyy', 1990, 2020)
+      expect(pipe('12 31 2000')).to.deep.equal({value: '12 31 2000', indexesOfPipedChars: []})
+    })
+
+    it('allows for a year at the bottom side of the range', () => {
+      let pipe = createAutoCorrectedDatePipe('mm dd yyyy', 1990, 2020)
+      expect(pipe('12 31 1990')).to.deep.equal({value: '12 31 1990', indexesOfPipedChars: []})
+    })
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3680,15 +3680,6 @@
           "dev": true,
           "optional": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3697,6 +3688,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -7615,15 +7615,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7633,6 +7624,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/website/src/choices.js
+++ b/website/src/choices.js
@@ -33,7 +33,15 @@ export default map(
     pipe: createAutoCorrectedDatePipe(),
     placeholder: 'Please enter a date',
     keepCharPositions: true,
-  }, {
+  },
+  {
+    name: 'Date (with min and max years between 1975 and 2020)',
+    mask: [/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/],
+    pipe: createAutoCorrectedDatePipe('dd mm yyyy', 1975, 2020),
+    placeholder: 'Please enter a date',
+    keepCharPositions: true,
+  },
+  {
     name: 'US dollar amount',
     mask: createNumberMask(),
     placeholder: 'Enter an amount',

--- a/website/src/helpPanel.js
+++ b/website/src/helpPanel.js
@@ -37,7 +37,25 @@ const HelpPanel = React.createClass({
             </p>
           </Panel>
         </Row>
-      ) || props.mask.instanceOf === 'createNumberMask' && (
+			) ||
+			props.choiceName === 'Date (with min and max years between 1975 and 2020)' && (
+				<Row>
+					<Panel title='Piped'>
+						<p>
+							User input in this configuration is passed through a <Links.pipe /> that
+							allows a min and max year.
+							For this example, the range is set from 1975 to 2020.
+              If you enter <code>0</code> in the 1st digit of the year, it will block the entry.
+              If you enter <code>1</code> in the 1st digit of the year, it will allow the entry.
+							If you enter <code>8</code> in the 1st digit of the year, it will block the entry.
+            </p>
+
+						<p>
+							It is using <Links.createAutoCorrectedDatePipe />, which is available as an <Links.addon />.
+            </p>
+					</Panel>
+				</Row>
+			) || props.mask.instanceOf === 'createNumberMask' && (
         <Row>
           <Panel title='Mask function'>
             <MaskFunctionDefinition maskLink={<Links.createNumberMask/>} />


### PR DESCRIPTION
This change was requested a few times and my team needed it for a project we're working on. Essentially it works by blocking or allowing numbers to be entered based on a range specified in the pipe.

It checks the substring against the range. So if the range is 1950 to 2000 and the user enters 1, it will allow because 1 is between 1 and 2. If the user enters 18, the pipe will block the input as 18 is not between 19 and 20... and so on.

I've added as many tests as I could and also added documentation to the site and readme for the pipe.