### PR TITLE
Fixes external control for React when the mask prop is false

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -61,7 +61,11 @@ export default function createTextMaskInputElement(config) {
 
       // In framework components that support reactivity, it's possible to turn off masking by passing
       // `false` for `mask` after initialization. See https://github.com/text-mask/text-mask/pull/359
-      if (providedMask === false) { return }
+      if (providedMask === false) {
+        // Even without a mask, the value should be updated externally
+        inputElement.value = getSafeRawValue(rawValue)
+        return
+      }
 
       // We check the provided `rawValue` before moving further.
       // If it's something we can't work with `getSafeRawValue` will throw.

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -61,11 +61,7 @@ export default function createTextMaskInputElement(config) {
 
       // In framework components that support reactivity, it's possible to turn off masking by passing
       // `false` for `mask` after initialization. See https://github.com/text-mask/text-mask/pull/359
-      if (providedMask === false) {
-        // Even without a mask, the value should be updated externally
-        inputElement.value = getSafeRawValue(rawValue)
-        return
-      }
+      if (providedMask === false) { return }
 
       // We check the provided `rawValue` before moving further.
       // If it's something we can't work with `getSafeRawValue` will throw.

--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -23,6 +23,7 @@ export default class MaskedInput extends React.PureComponent {
     this.textMaskInputElement = createTextMaskInputElement({
       inputElement: this.inputElement,
       ...props,
+      mask: props.mask === false ? (value) => Array(value.length).fill(/./) : props.mask,
     })
     this.textMaskInputElement.update(value)
   }


### PR DESCRIPTION
The `update` functions was ignoring external changes when the mask prop was `false`. To fix that I've changed the value even in that kind of situations.