### PR TITLE
Move common variables to constants file

### DIFF
--- a/core/src/adjustCaretPosition.js
+++ b/core/src/adjustCaretPosition.js
@@ -1,5 +1,4 @@
-const defaultArray = []
-const emptyString = ''
+import {defaultArray, emptyString} from './constants'
 
 export default function adjustCaretPosition({
   previousConformedValue = emptyString,

--- a/core/src/conformToMask.js
+++ b/core/src/conformToMask.js
@@ -1,8 +1,10 @@
 import {convertMaskToPlaceholder, isArray, processCaretTraps} from './utilities'
-import {placeholderChar as defaultPlaceholderChar, strFunction} from './constants'
-
-const emptyArray = []
-const emptyString = ''
+import {
+  emptyArray,
+  emptyString,
+  placeholderChar as defaultPlaceholderChar,
+  strFunction
+} from './constants'
 
 export default function conformToMask(rawValue = emptyString, mask = emptyArray, config = {}) {
   if (!isArray(mask)) {

--- a/core/src/constants.js
+++ b/core/src/constants.js
@@ -1,2 +1,5 @@
 export const placeholderChar = '_'
 export const strFunction = 'function'
+export const defaultArray = []
+export const emptyString = ''
+export const emptyArray = []

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -1,9 +1,12 @@
 import adjustCaretPosition from './adjustCaretPosition'
 import conformToMask from './conformToMask'
 import {convertMaskToPlaceholder, isString, isNumber, processCaretTraps} from './utilities'
-import {placeholderChar as defaultPlaceholderChar, strFunction} from './constants'
+import {
+  emptyString,
+  placeholderChar as defaultPlaceholderChar,
+  strFunction
+} from './constants'
 
-const emptyString = ''
 const strNone = 'none'
 const strObject = 'object'
 const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)

--- a/core/src/utilities.js
+++ b/core/src/utilities.js
@@ -1,6 +1,7 @@
-import {placeholderChar as defaultPlaceholderChar} from './constants'
-
-const emptyArray = []
+import {
+  emptyArray,
+  placeholderChar as defaultPlaceholderChar
+} from './constants'
 
 export function convertMaskToPlaceholder(mask = emptyArray, placeholderChar = defaultPlaceholderChar) {
   if (!isArray(mask)) {


### PR DESCRIPTION
Moving common variables to the constants file to prevent naming collisions when compiling with rollup.js