### PR TITLE
Add typing interface for number mask config

### DIFF
--- a/addons/dist/textMaskAddons.d.ts
+++ b/addons/dist/textMaskAddons.d.ts
@@ -1,3 +1,17 @@
+export interface NumberMaskConfig {
+    prefix?: string;
+    suffix?: string;
+    includeThousandsSeparator?: boolean;
+    thousandsSeparatorSymbol?: string;
+    allowDecimal?: boolean;
+    decimalSymbol?: string;
+    decimalLimit?: number;
+    integerLimit?: number;
+    requireDecimal?: boolean;
+    allowNegative?: boolean;
+    allowLeadingZeroes?: boolean;
+}
+
 export function createAutoCorrectedDatePipe(a: any): any
-export function createNumberMask(a: any): any
+export function createNumberMask(a: NumberMaskConfig): any
 export const emailMask:any


### PR DESCRIPTION
I find myself typo'ing this a lot and thought it was strange that it was so loosely typed.  I just added this config option for myself and figured it'd be good to give back.  I'm not sure what the other typings just exporting `foo` are for, but I left those alone and kept the interface in "addons" so that it imported cleaner.  Could do more cleaning, but I didn't want to do any sort of organization as I can't even tell if these are generated from previous commits.

Anyways, thanks!