### PR TITLE
 Fix createAutoCorrectedDatePipe type definition for TypeScript

### DIFF
--- a/addons/dist/textMaskAddons.d.ts
+++ b/addons/dist/textMaskAddons.d.ts
@@ -1,3 +1,3 @@
-export function createAutoCorrectedDatePipe(a: any): any
+export function createAutoCorrectedDatePipe(a: string, b: any): any
 export function createNumberMask(a: any): any
 export const emailMask:any


### PR DESCRIPTION
createAutoCorrectedDatePipe takes two parameters, it should be detailed in the .d.ts file.