### PR TITLE
Build angular2-text-mask with ng-packagr

### DIFF
--- a/angular2/package.json
+++ b/angular2/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "tsc -p example/tsconfig.json && concurrently \"tsc -w -p example/tsconfig.json\" lite-server ",
-    "build": "./node_modules/.bin/ngc -p tsconfig.json && rm -rf aot",
+    "build": "ng-packagr",
     "test": "karma start",
     "loud-lint": "node_modules/.bin/tslint -c tslint.json src/*.ts test/**/*.ts example/**/*.ts",
     "lint": "node_modules/.bin/tslint -c tslint.json src/*.ts test/**/*.ts example/**/*.ts || true",
@@ -56,6 +56,7 @@
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-typescript": "^3.0.4",
     "lite-server": "^2.2.2",
+    "ng-packagr": "^1.7.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "^5.0.1",
     "systemjs": "0.19.39",
@@ -66,5 +67,10 @@
   },
   "dependencies": {
     "text-mask-core": "^5.0.0"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/angular2TextMask.ts"
+    }
   }
 }

--- a/angular2/publish.sh
+++ b/angular2/publish.sh
@@ -13,6 +13,6 @@ npm run build
 
 generatedNpmVersion="$(npm version $version)"
 
-npm publish --access public
+npm publish dist --access public
 
 git tag "angular2-${generatedNpmVersion}"

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -1,7 +1,7 @@
 import { Directive, ElementRef, forwardRef, Input, Inject, NgModule, OnChanges, Optional, Provider, Renderer2, SimpleChanges } from '@angular/core'
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, COMPOSITION_BUFFER_MODE } from '@angular/forms'
 import {ɵgetDOM as getDOM} from '@angular/platform-browser'
-import { createTextMaskInputElement } from 'text-mask-core/dist/textMaskCore'
+const { createTextMaskInputElement, conformToMask } = require('text-mask-core')
 
 export class TextMaskConfig {
   mask: Array<string | RegExp> | ((raw: string) => Array<string | RegExp>) | false
@@ -140,4 +140,4 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
 })
 export class TextMaskModule {}
 
-export { conformToMask } from 'text-mask-core/dist/textMaskCore'
+export { conformToMask }


### PR DESCRIPTION
This publishes the `angular2-text-mask` in the angular package format. This will allow the angular core to be more treeshakable once ivy comes out, plus helps to workaround [this bug](https://github.com/angular/angular-cli/issues/12646#issuecomment-432292721)