### PR TITLE
Fixes #836 - prevents constantly calling bind when mask is an Array

### DIFF
--- a/vue/src/vueTextMask.js
+++ b/vue/src/vueTextMask.js
@@ -21,43 +21,30 @@ export default {
   props: {
     value: {
       type: String,
-      required: false,
       default: ''
     },
-
     mask: {
       type: [Array, Function, Boolean, Object],
       required: true
     },
-
-    guide: {
-      type: Boolean,
-      required: false
-    },
-
-    placeholderChar: {
-      type: String,
-      required: false
-    },
-
-    keepCharPositions: {
-      type: Boolean,
-      required: false
-    },
-
-    pipe: {
-      type: Function,
-      required: false
-    },
-
-    showMask: {
-      type: Boolean,
-      required: false
-    }
+    guide: Boolean,
+    placeholderChar: String,
+    keepCharPositions: Boolean,
+    pipe: Function,
+    showMask: Boolean,
   },
 
   mounted() {
     this.initMask()
+    this.$watch(vm => {
+      return [
+        vm.guide,
+        vm.placeholderChar,
+        vm.keepCharPositions,
+        vm.pipe,
+        vm.showMask
+      ].join()
+    }, () => this.bind())
   },
 
   methods: {
@@ -86,32 +73,15 @@ export default {
     },
   },
 
-  watch: {
+  watch: { 
+    // other 'watch'ers defined in mounted hook
+
     mask(newMask, oldMask) {
+      // NB: this gets called repeatedly if 'mask' is defined in the template instead of in data
       // Check if the mask has changed (Vue cannot detect whether an array has changed)
-      if (this.mask !== oldMask) {
+      if (JSON.stringify(oldMask) !== JSON.stringify(newMask)) {
         this.bind()
       }
-    },
-
-    guide() {
-      this.bind()
-    },
-
-    placeholderChar() {
-      this.bind()
-    },
-
-    keepCharPositions() {
-      this.bind()
-    },
-
-    pipe() {
-      this.bind()
-    },
-
-    showMask() {
-      this.bind()
     }
   }
 }


### PR DESCRIPTION
The most important change here is on line 82, vue-text-mask's current equivalence check for arrays doesn't work and thus bashes the `bind` function, probably causing quite a few bugs, but the most obvious are ones like #836.

I also think it might make sense to add a note to the docs encouraging users to create their masks in `data` instead of in the `template` — this will prevent the watcher from firing constantly, even if this is fixed.

I'm happy to undo the other changes that make the component code more terse and idiomatic if wanted.