### PR TITLE
Fixes #687 - Adding innerRef prop to get ref to underlying DOM node

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -80,6 +80,27 @@ const MyStyledInput = styled.input`
 `;
 ```
 
+## Using DOM Refs
+
+You can obtain a ref to the underlying DOM element by passing a callback to the `innerRef` prop.
+
+In most cases [refs should be avoided](https://reactjs.org/docs/refs-and-the-dom.html), however there are some good use cases.
+Note that this is using "callback refs" and not the new `createRef()` API introduced in React 16.3.
+
+For example:
+
+```js
+<MaskedInput
+  mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+  placeholder="Enter a phone number"
+  innerRef={el => this.phoneRef = el}
+/>
+
+focusPhoneInput() {
+  if (this.phoneRef) this.phoneRef.focus();
+}
+```
+
 ## Contributing
 
 We would love some contributions! Check out [this document](https://github.com/text-mask/text-mask/blob/master/howToContribute.md#readme) to get started.

--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -15,6 +15,9 @@ export default class MaskedInput extends React.PureComponent {
 
   setRef(inputElement) {
     this.inputElement = inputElement
+    if (typeof this.props.innerRef === 'function') {
+      this.props.innerRef(inputElement)
+    }
   }
 
   initTextMask() {
@@ -70,6 +73,7 @@ export default class MaskedInput extends React.PureComponent {
     delete props.onBlur
     delete props.onChange
     delete props.showMask
+    delete props.innerRef
 
     return render(this.setRef, {
       onBlur: this.onBlur,
@@ -110,6 +114,7 @@ MaskedInput.propTypes = {
   placeholderChar: PropTypes.string,
   keepCharPositions: PropTypes.bool,
   showMask: PropTypes.bool,
+  innerRef: PropTypes.func,
 }
 
 MaskedInput.defaultProps = {


### PR DESCRIPTION
Adding the ability to pass an `innerRef` prop using the "callback ref" style to get the ref of the underlying DOM element. This works for both the default `<input>` element as well as custom render components such as the styled-components example in the README.

This would provide a solution to #687.

I used the "callback ref" style since the project is not using the new `createRef()` API from React 16.3. I did see there is a pending PR that does the upgrade, #865, so this would need to be considered when merging that PR.