### PR TITLE
Fix error in case of trailing dot in date format (e.g. "yyyy.mm.dd.")

### DIFF
--- a/addons/src/createAutoCorrectedDatePipe.js
+++ b/addons/src/createAutoCorrectedDatePipe.js
@@ -6,6 +6,7 @@ export default function createAutoCorrectedDatePipe(dateFormat = 'mm dd yyyy', {
 } = {}) {
   const dateFormatArray = dateFormat
     .split(/[^dmyHMS]+/)
+    .filter(Boolean)
     .sort((a, b) => formatOrder.indexOf(a) - formatOrder.indexOf(b))
   return function(conformedValue) {
     const indexesOfPipedChars = []


### PR DESCRIPTION
With a trailing dot `yyyy.mm.dd.` could be a possible date format (e.g. in Hungarian).