### PR TITLE
Fixes #891 - Cursor jumping to the end of input when modifying

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -78,7 +78,7 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
 
     // set the initial value for cases where the mask is disabled
     const normalizedValue = value == null ? '' : value
-    this._renderer.setProperty(this.inputElement, 'value', normalizedValue)
+    this._renderer.setAttribute(this.inputElement, 'value', normalizedValue)
 
     if (this.textMaskInputElement !== undefined) {
       this.textMaskInputElement.update(value)


### PR DESCRIPTION
This fixes https://github.com/text-mask/text-mask/issues/891.
Tested on: 
- iOS 11, 12
- Android 7, 6 
- Chrome 72, IE 11