### PR TITLE
Add hook for parent component to be notified when input value changes

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -26,7 +26,8 @@ export default function createTextMaskInputElement(config) {
       pipe,
       placeholderChar = defaultPlaceholderChar,
       keepCharPositions = false,
-      showMask = false
+      showMask = false,
+      onSetInputValue = () => {}
     } = config) {
       // if `rawValue` is `undefined`, read from the `inputElement`
       if (typeof rawValue === 'undefined') {
@@ -169,6 +170,7 @@ export default function createTextMaskInputElement(config) {
 
       inputElement.value = inputElementValue // set the input value
       safeSetSelection(inputElement, adjustedCaretPosition) // adjust caret position
+      onSetInputValue(inputElementValue)
     }
   }
 }

--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -70,6 +70,7 @@ export default class MaskedInput extends React.PureComponent {
     delete props.onBlur
     delete props.onChange
     delete props.showMask
+    delete props.onSetInputValue
 
     return render(this.setRef, {
       onBlur: this.onBlur,
@@ -110,6 +111,7 @@ MaskedInput.propTypes = {
   placeholderChar: PropTypes.string,
   keepCharPositions: PropTypes.bool,
   showMask: PropTypes.bool,
+  onSetInputValue: PropTypes.func,
 }
 
 MaskedInput.defaultProps = {


### PR DESCRIPTION
Text mask component directly modifies the input element's dom `value`. This commit adds a hook prop that can be used to notify parent components when the input's value changes so that they can update their own state to reflect the new value in the dom.

This came up for me when using `MaskedInput` inside a `Formik` form. When the `mask` prop to `MaskedInput` changes, it can change the value of the input element and leave the value stored in `Formik` stale. With this `onSetInputValue` hook prop, we can provide a function that syncs the `Formik` state (via `setFieldValue`) when the `value` in the dom is changed.

Repro here: https://codesandbox.io/embed/l7or5346wq

Looking for feedback on general approach, naming, etc. Then I'll add documentation and tests as needed.