### PR TITLE
[ISSUE-932] Add a config option to specify the deferred selection behavior

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -110,6 +110,12 @@ string to contain a guide or no. The `guide` is basically the placeholder charac
 mask hard characters. For example, with mask `['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]`, input `123` with `guide` set to
 `true` would return `(123) ___-____`. With `guide` set to `false`, it would return `(123) `.
 
+* `deferredSelectionEnabled` (boolean) (defaults to `true` if `navigator.userAgent` includes
+'Android' and `false` otherwise): this specifies whether the caret position on input element
+should be set after a timeout after text value is updated. The default value works for most
+use cases (e.g. Android, iOS, Mac, Linux, and Windows). In case the behavior needs to be
+customized (e.g. Tizen), this config option allows you to specify a desired behavior.
+
 * `previousConformedValue` (string) (required): this is the previous `output` of `conformToMask`.
 If you're calling `conformToMask` for the first time, you don't have to pass this value.
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "text-mask-core",
+  "version": "5.1.2",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
## Issue

- #945: Add a config option to specify the deferred selection behavior

## Background

 - When the `text-mask` set a range selection on Input Element, it uses a deferred selection behavior if `navigator.userAgent` value has 'Android'.
 - However, on a recent version of Android (e.g. Galaxy S9), the deferred selection behavior is unnecessary (if not undesirable). Also on some other OSes (e.g. Tizen), the deferred selection behavior is necessary for text selection to work properly.

## What

- Add a config option to specify the deferred selection behavior as needed to override the default behavior.
- This change is backward-compatible. If `deferredSelectionEnabled` config option is not specified, the same deferred selection behavior as before should be used.
