### PR TITLE
Fix Uncaught DOMException

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -177,6 +177,10 @@ function safeSetSelection(element, selectionPosition) {
   if (document.activeElement === element) {
     if (isAndroid) {
       defer(() => element.setSelectionRange(selectionPosition, selectionPosition, strNone), 0)
+    } else if (element.type === 'number') {
+      element.type = 'text'
+      element.setSelectionRange(selectionPosition, selectionPosition, strNone)
+      element.type = 'number'
     } else {
       element.setSelectionRange(selectionPosition, selectionPosition, strNone)
     }


### PR DESCRIPTION
`Uncaught DOMException: Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('number') does not support selection.`

Fix this error for inputs of type number with mask.