### PR TITLE
Add support to indian lakhs separator

### DIFF
--- a/addons/src/createNumberMask.js
+++ b/addons/src/createNumberMask.js
@@ -13,6 +13,7 @@ export default function createNumberMask({
   prefix = dollarSign,
   suffix = emptyString,
   includeThousandsSeparator = true,
+  includeLakhsSeparator = false,
   thousandsSeparatorSymbol = comma,
   allowDecimal = false,
   decimalSymbol = period,
@@ -85,7 +86,10 @@ export default function createNumberMask({
       integer = integer.replace(/^0+(0$|[^0])/, '$1')
     }
 
-    integer = (includeThousandsSeparator) ? addThousandsSeparator(integer, thousandsSeparatorSymbol) : integer
+    integer = includeThousandsSeparator ? addThousandsSeparator(integer, thousandsSeparatorSymbol) : integer
+
+    // if both includeLakhsSeparator and includeThousandsSeparator is true use thousandsSeparator
+    integer = includeLakhsSeparator && !includeThousandsSeparator ? addLakhsSeparator(integer) : integer;
 
     mask = convertToMask(integer)
 
@@ -143,4 +147,8 @@ function convertToMask(strNumber) {
 // http://stackoverflow.com/a/10899795/604296
 function addThousandsSeparator(n, thousandsSeparatorSymbol) {
   return n.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparatorSymbol)
+}
+
+function addLakhsSeparator(n) {
+  return n.replace(/(\d)(?=(\d\d)+\d$)/g, "$1,");
 }

--- a/addons/test/createNumberMask.spec.js
+++ b/addons/test/createNumberMask.spec.js
@@ -53,6 +53,16 @@ describe('createNumberMask', () => {
     expect(numberMask('1000')).to.deep.equal(['$', /\d/, '.', /\d/, /\d/, /\d/])
   })
 
+  it('should use thousand separator by default when both lakh and thousand separator are true', () => {
+    let numberMask = createNumberMask({includeLakhsSeparator: true})
+    expect(numberMask('100000')).to.deep.equal([ '$', /\d/, /\d/, /\d/, ',', /\d/, /\d/, /\d/ ])
+  })
+
+  it('should use lakh separator', () => {
+    let numberMask = createNumberMask({includeLakhsSeparator: true, includeThousandsSeparator: false, prefix:'₹'})
+    expect(numberMask('100000')).to.deep.equal([ '₹', /\d/, ',', /\d/, /\d/, ',', /\d/, /\d/, /\d/ ])
+  })
+
   it('can be configured to accept a fraction and returns the fraction separator with caret traps', () => {
     let numberMask = createNumberMask({allowDecimal: true})
 


### PR DESCRIPTION
Adding an option in the config to use indian lakhs separator . 
eg : 1,23,456.789 . 

Things to Note : 
When both the thousand and lakhs separator are true , use thousand separator instead to avoid collision.

Indian currency symbol is '₹' . So the ideal config to use laksh separator would be 
```
createNumberMask({includeLakhsSeparator: true, includeThousandsSeparator: false, prefix:'₹' })
``` 