### PR TITLE
Fix onChange not Firing when Deleting All Text

### DIFF
--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -74,7 +74,7 @@ export default class MaskedInput extends React.PureComponent {
     return render(this.setRef, {
       onBlur: this.onBlur,
       onChange: this.onChange,
-      defaultValue: this.props.value,
+      value: this.props.value,
       ...props,
     })
   }


### PR DESCRIPTION
When deleting the entire value of a field at once, e.g. `cmd+backspace`, onChange is not called. This is most likely due to `value` being null, so when the text is deleted no change is detected. 

Fixes issue #992