### PR TITLE
Update lastValue whenever ngModel property update programmatically

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -81,7 +81,8 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
     this._renderer.setProperty(this.inputElement, 'value', normalizedValue)
 
     if (this.textMaskInputElement !== undefined) {
-      this.textMaskInputElement.update(value)
+      this.textMaskInputElement.update(value);
+      this.lastValue = value;
     }
   }
 


### PR DESCRIPTION
**Scenario:**
- We have two textbox bind with `ngModel` properties respectively and `(ngModelChange)` event bind to these.

- On change in first textbox value need to update second textbox `ngModel` property which is reflecting.
   (when you have update `ngModel` property programmatically then it trigger `writeValue` function but not update the `lastValue` hence then you change the `ngModel` value and its not triggered `this._onChange();`).

- But After programmatically update value, when remove the value from second textbox `(ngModelChange)` will not trigger because `this.lastValue`  has not been updated in previous `writeValue` function.